### PR TITLE
Using MapDB as the Package Database Format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,12 @@
                 <artifactId>guava</artifactId>
                 <version>18.0</version>
             </dependency>
-        </dependencies>
+			<dependency>
+				<groupId>org.mapdb</groupId>
+				<artifactId>mapdb</artifactId>
+				<version>1.0.7</version>
+			</dependency>
+		</dependencies>
 		
 		
 	</dependencyManagement>

--- a/services/package-manager/pom.xml
+++ b/services/package-manager/pom.xml
@@ -30,6 +30,13 @@
             <version>2.0.0-SNAPSHOT</version>
         </dependency>
 
+        <!-- MapDB for package database persistence -->
+
+        <dependency>
+            <groupId>org.mapdb</groupId>
+            <artifactId>mapdb</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageDatabase.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageDatabase.java
@@ -1,0 +1,36 @@
+package org.openthinclient.pkgmgr;
+
+import org.openthinclient.util.dpkg.*;
+import org.openthinclient.util.dpkg.Package;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public interface PackageDatabase {
+	void save() throws IOException;
+
+	void close();
+
+	boolean isPackageInstalled(String name);
+
+	boolean isPackageInstalledDontVerifyVersion(String name);
+
+	Map<String, Package> getProvidedPackages();
+
+	@SuppressWarnings("unchecked")
+	Collection<Package> getPackages();
+
+	void addPackage(Package pkg);
+
+	void addPackageDontVerifyVersion(Package pkg);
+
+	Package getPackage(String name);
+
+	List<Package> getProvidesPackages(String provided);
+
+	List<Package> getDependency(Package pack);
+
+	boolean removePackage(Package pkg);
+}

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageDatabase.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageDatabase.java
@@ -1,6 +1,6 @@
 package org.openthinclient.pkgmgr;
 
-import org.openthinclient.util.dpkg.*;
+
 import org.openthinclient.util.dpkg.Package;
 
 import java.io.IOException;
@@ -28,6 +28,12 @@ public interface PackageDatabase {
 
 	Package getPackage(String name);
 
+	/**
+	 * Return a {@link List} of all {@link Package packages} providing the requested feature/virtual package.
+	 *
+	 * @param provided the feature/virtual package requested
+	 * @return a list of Packages which are providing the requested feature/virtual package
+	 */
 	List<Package> getProvidesPackages(String provided);
 
 	List<Package> getDependency(Package pack);

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageDatabaseFactory.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageDatabaseFactory.java
@@ -1,0 +1,10 @@
+package org.openthinclient.pkgmgr;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+public interface PackageDatabaseFactory {
+
+  PackageDatabase create(Path targetPath) throws IOException;
+
+}

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageManagerFactory.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageManagerFactory.java
@@ -20,6 +20,7 @@
  ******************************************************************************/
 package org.openthinclient.pkgmgr;
 
+import org.openthinclient.pkgmgr.impl.MapDBPackageDatabase;
 import org.openthinclient.util.dpkg.DPKGPackageManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +42,9 @@ public class PackageManagerFactory {
 
 	public static DPKGPackageManager createPackageManager(PackageManagerConfiguration configuration){
 
-		final org.openthinclient.util.dpkg.PackageDatabase.SerializationPackageDatabaseFactory packageDatabaseFactory = new org.openthinclient.util.dpkg.PackageDatabase.SerializationPackageDatabaseFactory();
+//		final org.openthinclient.util.dpkg.PackageDatabase.SerializationPackageDatabaseFactory packageDatabaseFactory = new org.openthinclient.util.dpkg.PackageDatabase.SerializationPackageDatabaseFactory();
+
+		MapDBPackageDatabase.MapDBPackageDatabaseFactory packageDatabaseFactory = new MapDBPackageDatabase.MapDBPackageDatabaseFactory();
 
 		try {
 

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageManagerFactory.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageManagerFactory.java
@@ -21,7 +21,6 @@
 package org.openthinclient.pkgmgr;
 
 import org.openthinclient.util.dpkg.DPKGPackageManager;
-import org.openthinclient.util.dpkg.PackageDatabase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,27 +41,18 @@ public class PackageManagerFactory {
 
 	public static DPKGPackageManager createPackageManager(PackageManagerConfiguration configuration){
 
+		final org.openthinclient.util.dpkg.PackageDatabase.SerializationPackageDatabaseFactory packageDatabaseFactory = new org.openthinclient.util.dpkg.PackageDatabase.SerializationPackageDatabaseFactory();
+
 		try {
 
-      org.openthinclient.pkgmgr.PackageDatabase cacheDB = null;
-      org.openthinclient.pkgmgr.PackageDatabase archivesDB = PackageDatabase.open(configuration.getArchivesDB());
-      org.openthinclient.pkgmgr.PackageDatabase installedDB = PackageDatabase.open(configuration.getPackageDB());
-      org.openthinclient.pkgmgr.PackageDatabase removedDB = PackageDatabase.open(configuration.getOldDB());
+      PackageDatabase cacheDB = packageDatabaseFactory.create(configuration.getCacheDB().toPath());
+      PackageDatabase archivesDB = packageDatabaseFactory.create(configuration.getArchivesDB().toPath());
+      PackageDatabase installedDB = packageDatabaseFactory.create(configuration.getPackageDB().toPath());
+      PackageDatabase removedDB = packageDatabaseFactory.create(configuration.getOldDB().toPath());
       PackageManagerTaskSummary taskSummary = new PackageManagerTaskSummary();
 
-			// initially parse the sources list
-			final SourcesListParser parser = new SourcesListParser();
-			final SourcesList sourcesList = parser.parse(configuration.getSourcesList().toPath());
-
-			try {
-				cacheDB = new UpdateDatabase(configuration.getCacheDB(), configuration.getListsDir(), configuration, sourcesList)
-						.doUpdate(false, taskSummary, configuration.getProxyConfiguration());
-			} catch (PackageManagerException e) {
-				logger.error("Unable to create the Cache Database!",e);
-				taskSummary.addWarning("Unable to create the Cache Database! Cause: " + e.getMessage());
-			}
 			DPKGPackageManager dpkgPackageManager = new DPKGPackageManager(cacheDB, removedDB, installedDB,
-					archivesDB, configuration);
+					archivesDB, configuration, packageDatabaseFactory);
 			dpkgPackageManager.setTaskSummary(taskSummary);
 			return dpkgPackageManager;
 		} catch (final IOException e) {

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageManagerFactory.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/PackageManagerFactory.java
@@ -44,10 +44,10 @@ public class PackageManagerFactory {
 
 		try {
 
-      PackageDatabase cacheDB = null;
-      PackageDatabase archivesDB = PackageDatabase.open(configuration.getArchivesDB());
-      PackageDatabase installedDB = PackageDatabase.open(configuration.getPackageDB());
-      PackageDatabase removedDB = PackageDatabase.open(configuration.getOldDB());
+      org.openthinclient.pkgmgr.PackageDatabase cacheDB = null;
+      org.openthinclient.pkgmgr.PackageDatabase archivesDB = PackageDatabase.open(configuration.getArchivesDB());
+      org.openthinclient.pkgmgr.PackageDatabase installedDB = PackageDatabase.open(configuration.getPackageDB());
+      org.openthinclient.pkgmgr.PackageDatabase removedDB = PackageDatabase.open(configuration.getOldDB());
       PackageManagerTaskSummary taskSummary = new PackageManagerTaskSummary();
 
 			// initially parse the sources list

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/UpdateDatabase.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/UpdateDatabase.java
@@ -22,7 +22,7 @@ package org.openthinclient.pkgmgr;
 
 import org.openthinclient.pkgmgr.connect.ConnectToServer;
 import org.openthinclient.pkgmgr.connect.SearchForServerFile;
-import org.openthinclient.util.dpkg.DPKGPackageManager;
+import org.openthinclient.util.dpkg.DPKGPackageFactory;
 import org.openthinclient.util.dpkg.Package;
 import org.openthinclient.util.dpkg.UrlAndFile;
 import org.slf4j.Logger;

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/UpdateDatabase.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/UpdateDatabase.java
@@ -64,11 +64,11 @@ public class UpdateDatabase {
 		this.sourcesList = sourcesList;
 	}
 
-	public PackageDatabase doUpdate(boolean isStart, PackageManagerTaskSummary taskSummary, PackageManagerConfiguration.ProxyConfiguration proxyConfiguration)
+	public org.openthinclient.pkgmgr.PackageDatabase doUpdate(boolean isStart, PackageManagerTaskSummary taskSummary, PackageManagerConfiguration.ProxyConfiguration proxyConfiguration)
 			throws PackageManagerException {
 		if (!isStart)
 			try {
-				final PackageDatabase packDB = PackageDatabase.open(cacheDatabase);
+				final org.openthinclient.pkgmgr.PackageDatabase packDB = PackageDatabase.open(cacheDatabase);
 				packDB.save();
 				return packDB;
 			} catch (final IOException e) {
@@ -77,7 +77,7 @@ public class UpdateDatabase {
 			}
 		else {
 			List<Package> packages;
-			PackageDatabase packDB;
+			org.openthinclient.pkgmgr.PackageDatabase packDB;
 			List<UrlAndFile> updatedFiles = null;
 			final SearchForServerFile seFoSeFi = new SearchForServerFile(configuration, sourcesList);
 			updatedFiles = seFoSeFi.checkForNewUpdatedFiles(taskSummary);
@@ -132,10 +132,10 @@ public class UpdateDatabase {
 		}
 	}
 
-	public PackageDatabase doUpdate(DPKGPackageManager pm, PackageManagerTaskSummary taskSummary, PackageManagerConfiguration.ProxyConfiguration proxyConfiguration)
+	public org.openthinclient.pkgmgr.PackageDatabase doUpdate(DPKGPackageManager pm, PackageManagerTaskSummary taskSummary, PackageManagerConfiguration.ProxyConfiguration proxyConfiguration)
 			throws PackageManagerException {
 		List<Package> packages;
-		PackageDatabase packDB;
+		org.openthinclient.pkgmgr.PackageDatabase packDB;
 		List<UrlAndFile> updatedFiles = null;
 		final SearchForServerFile seFoSeFi = new SearchForServerFile(configuration, sourcesList);
 		updatedFiles = seFoSeFi.checkForNewUpdatedFiles(taskSummary);

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/UpdateDatabase.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/UpdateDatabase.java
@@ -20,21 +20,20 @@
  ******************************************************************************/
 package org.openthinclient.pkgmgr;
 
+import org.openthinclient.pkgmgr.connect.ConnectToServer;
+import org.openthinclient.pkgmgr.connect.SearchForServerFile;
+import org.openthinclient.util.dpkg.DPKGPackageManager;
+import org.openthinclient.util.dpkg.Package;
+import org.openthinclient.util.dpkg.UrlAndFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.openthinclient.pkgmgr.connect.ConnectToServer;
-import org.openthinclient.pkgmgr.connect.SearchForServerFile;
-import org.openthinclient.util.dpkg.DPKGPackageManager;
-import org.openthinclient.util.dpkg.Package;
-import org.openthinclient.util.dpkg.PackageDatabase;
-import org.openthinclient.util.dpkg.UrlAndFile;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * removes the actually cache database, connect to the internet load the newest
@@ -51,91 +50,25 @@ public class UpdateDatabase {
 	private static File changelogDir;
 	private static final Logger logger = LoggerFactory.getLogger(UpdateDatabase.class);
   private final PackageManagerConfiguration configuration;
+	private final PackageDatabaseFactory packageDatabaseFactory;
 	private final SourcesList sourcesList;
 
-	public UpdateDatabase(File cacheDatabase, File chlogDir, PackageManagerConfiguration configuration, SourcesList sourcesList) {
-    this(configuration, sourcesList);
-    UpdateDatabase.cacheDatabase = cacheDatabase;
-    changelogDir = chlogDir;
-  }
+	public UpdateDatabase(File cacheDatabase, File chlogDir, PackageManagerConfiguration configuration, PackageDatabaseFactory packageDatabaseFactory, SourcesList sourcesList) {
+		this(configuration, packageDatabaseFactory, sourcesList);
+		UpdateDatabase.cacheDatabase = cacheDatabase;
+		changelogDir = chlogDir;
+	}
 
-	public UpdateDatabase(PackageManagerConfiguration configuration, SourcesList sourcesList) {
-    this.configuration = configuration;
+	public UpdateDatabase(PackageManagerConfiguration configuration, PackageDatabaseFactory packageDatabaseFactory, SourcesList sourcesList) {
+		this.configuration = configuration;
+		this.packageDatabaseFactory = packageDatabaseFactory;
 		this.sourcesList = sourcesList;
 	}
 
-	public org.openthinclient.pkgmgr.PackageDatabase doUpdate(boolean isStart, PackageManagerTaskSummary taskSummary, PackageManagerConfiguration.ProxyConfiguration proxyConfiguration)
-			throws PackageManagerException {
-		if (!isStart)
-			try {
-				final org.openthinclient.pkgmgr.PackageDatabase packDB = PackageDatabase.open(cacheDatabase);
-				packDB.save();
-				return packDB;
-			} catch (final IOException e) {
-				logger.error("Failed to open package database", e);
-				throw new PackageManagerException(e);
-			}
-		else {
-			List<Package> packages;
-			org.openthinclient.pkgmgr.PackageDatabase packDB;
-			List<UrlAndFile> updatedFiles = null;
-			final SearchForServerFile seFoSeFi = new SearchForServerFile(configuration, sourcesList);
-			updatedFiles = seFoSeFi.checkForNewUpdatedFiles(taskSummary);
-			if (null == updatedFiles)
-				throw new PackageManagerException(I18N.getMessage("interface.noFilesAvailable"));
-			packages = new ArrayList<Package>();
-			for (int i = 0; i < updatedFiles.size(); i++)
-				try {
-					final List<Package> packageList = new ArrayList<Package>();
-					packageList.addAll(new DPKGPackageFactory(null)
-							.getPackage(updatedFiles.get(i).getFile()));
-					for (final Package pkg : packageList) {
-						packages.add(pkg);
-						final Package p = packages.get(packages.size() - 1);
-						p.setServerPath(updatedFiles.get(i).getUrl());
-						p.setChangelogDir(updatedFiles.get(i).getChangelogDir());
-						downloadChangelogFile(proxyConfiguration, pkg, changelogDir, updatedFiles.get(i)
-								.getChangelogDir(), taskSummary);
-					}
-				} catch (final IOException e) {
-					e.printStackTrace();
-					throw new PackageManagerException(e);
-				}
-			packDB = null;
-			if ((cacheDatabase).isFile())
-				(cacheDatabase).delete();
-			try {
-				packDB = PackageDatabase.open(cacheDatabase);
-			} catch (IOException e1) {
-				e1.printStackTrace();
-				logger.error("failed to open package database", e1);
-				throw new PackageManagerException(e1);
-			}
-			for (int i = 0; i < packages.size(); i++) {
-				if (!packDB.isPackageInstalled(packages.get(i).getName())) {
-					packDB.addPackage(packages.get(i));
-					continue;
-				}
-				final int n = packDB.getPackage(packages.get(i).getName()).getVersion()
-						.compareTo(packages.get(i).getVersion());
-				if (n == -1)
-					packDB.addPackage(packages.get(i));
-			}
-
-			try {
-				packDB.save();
-			} catch (IOException e) {
-				logger.error("failed to save package database", e);
-				throw new PackageManagerException(e);
-			}
-			return packDB;
-		}
-	}
-
-	public org.openthinclient.pkgmgr.PackageDatabase doUpdate(DPKGPackageManager pm, PackageManagerTaskSummary taskSummary, PackageManagerConfiguration.ProxyConfiguration proxyConfiguration)
-			throws PackageManagerException {
+	public PackageDatabase doUpdate(PackageManagerTaskSummary taskSummary, PackageManagerConfiguration.ProxyConfiguration proxyConfiguration)
+					throws PackageManagerException {
 		List<Package> packages;
-		org.openthinclient.pkgmgr.PackageDatabase packDB;
+		PackageDatabase packDB;
 		List<UrlAndFile> updatedFiles = null;
 		final SearchForServerFile seFoSeFi = new SearchForServerFile(configuration, sourcesList);
 		updatedFiles = seFoSeFi.checkForNewUpdatedFiles(taskSummary);
@@ -145,22 +78,17 @@ public class UpdateDatabase {
 		for (int i = 0; i < updatedFiles.size(); i++)
 			try {
 				final List<Package> packageList = new ArrayList<Package>();
-				packageList.addAll(new DPKGPackageFactory(pm).getPackage(updatedFiles
-						.get(i).getFile()));
+				packageList.addAll(new DPKGPackageFactory(null)
+								.getPackage(updatedFiles.get(i).getFile()));
 				for (final Package pkg : packageList) {
 					packages.add(pkg);
 					final Package p = packages.get(packages.size() - 1);
 					p.setServerPath(updatedFiles.get(i).getUrl());
 					p.setChangelogDir(updatedFiles.get(i).getChangelogDir());
 					downloadChangelogFile(proxyConfiguration, pkg, changelogDir, updatedFiles.get(i)
-							.getChangelogDir(), taskSummary);
+									.getChangelogDir(), taskSummary);
 				}
-
 			} catch (final IOException e) {
-				String errormessage = I18N.getMessage("UpdateDatabase.doUpdate.GeneratePackages.IOException");
-				if (null != taskSummary)
-					taskSummary.addWarning(errormessage + e);
-				logger.error(errormessage, e);
 				e.printStackTrace();
 				throw new PackageManagerException(e);
 			}
@@ -168,13 +96,11 @@ public class UpdateDatabase {
 		if ((cacheDatabase).isFile())
 			(cacheDatabase).delete();
 		try {
-			packDB = PackageDatabase.open(cacheDatabase);
+			packDB = packageDatabaseFactory.create(cacheDatabase.toPath());
 		} catch (IOException e1) {
 			e1.printStackTrace();
-			logger
-					.error(
-							I18N.getMessage("UpdateDatabase.doUpdate.OpenDatabase.IOException"),
-							e1);
+			logger.error("failed to open package database", e1);
+			throw new PackageManagerException(e1);
 		}
 		for (int i = 0; i < packages.size(); i++) {
 			if (!packDB.isPackageInstalled(packages.get(i).getName())) {
@@ -182,7 +108,7 @@ public class UpdateDatabase {
 				continue;
 			}
 			final int n = packDB.getPackage(packages.get(i).getName()).getVersion()
-					.compareTo(packages.get(i).getVersion());
+							.compareTo(packages.get(i).getVersion());
 			if (n == -1)
 				packDB.addPackage(packages.get(i));
 		}
@@ -190,13 +116,10 @@ public class UpdateDatabase {
 		try {
 			packDB.save();
 		} catch (IOException e) {
-			logger
-					.error(I18N.getMessage("UpdateDatabase.doUpdate.SaveDatabase.IOException"),
-							e);
-			e.printStackTrace();
+			logger.error("failed to save package database", e);
+			throw new PackageManagerException(e);
 		}
 		return packDB;
-
 	}
 
   private static boolean downloadChangelogFile(PackageManagerConfiguration.ProxyConfiguration proxyConfiguration, Package pkg,

--- a/services/package-manager/src/main/java/org/openthinclient/pkgmgr/impl/MapDBPackageDatabase.java
+++ b/services/package-manager/src/main/java/org/openthinclient/pkgmgr/impl/MapDBPackageDatabase.java
@@ -1,0 +1,257 @@
+package org.openthinclient.pkgmgr.impl;
+
+import org.mapdb.DB;
+import org.mapdb.DBMaker;
+import org.openthinclient.pkgmgr.PackageDatabase;
+import org.openthinclient.pkgmgr.PackageDatabaseFactory;
+import org.openthinclient.util.dpkg.ANDReference;
+import org.openthinclient.util.dpkg.Package;
+import org.openthinclient.util.dpkg.PackageReference;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class MapDBPackageDatabase implements PackageDatabase {
+  private final DB db;
+  private final NavigableSet<Package> packages;
+
+  public MapDBPackageDatabase(DB db, NavigableSet<Package> packages) {
+    this.db = db;
+    this.packages = packages;
+  }
+
+  @Override
+  public void save() throws IOException {
+    db.commit();
+  }
+
+  @Override
+  public void close() {
+    db.close();
+  }
+
+  @Override
+  public boolean isPackageInstalled(String name) {
+    final Optional<Package> result = getPackageByName(name);
+    return result.isPresent();
+  }
+
+  /**
+   * This method will traverse all packages in this database and find the newest (in regards to the version) Package contained.
+   *
+   * @param name
+   * @return
+   */
+  private Optional<Package> getPackageByName(String name) {
+    return packages.stream() //
+            .filter(pkg -> pkg.getName().equals(name)) //
+            .sorted(this::comparePackageVersionDesc)
+            .findFirst();
+  }
+
+  /**
+   * Creates a Comparator that sorts the packages in descending order. That is, the highest version will come first.
+   *
+   * @return
+   */
+  private int comparePackageVersionDesc(Package pkg1, Package pkg2) {
+    return pkg2.getVersion().compareTo(pkg1.getVersion());
+  }
+
+  @Override
+  public boolean isPackageInstalledDontVerifyVersion(String name) {
+    // verify what version?
+    return isPackageInstalled(name);
+  }
+
+  @Override
+  public Map<String, Package> getProvidedPackages() {
+
+    final Map<String, Package> latestPackageVersions = getLatestPackageVersions();
+
+    // re-add all packages that do provide another "virtual" package
+    Map<String, List<Package>> virtualPackages = new HashMap<>();
+
+    // search for all packages providing another virtual package
+    // this intermediate step is required to collect all package versions.
+    // The newest version for a provided package will be selected in the next step.
+    packages.stream()
+            .filter(this::hasProvidedPackages)
+            .forEach(pkg -> {
+              getProvidedPackages(pkg).forEach(ref -> {
+
+                        List<Package> packages = virtualPackages.get(ref.getName());
+
+                        if (packages == null) {
+                          packages = new ArrayList<>();
+                          virtualPackages.put(ref.getName(), packages);
+                        }
+
+                        packages.add(pkg);
+                      }
+              );
+            });
+
+    // process all virtual packages and select the newest package version of the package list.
+    // this package will then be added to the latestPackageVersions map
+    virtualPackages.forEach((pkgName, packages) ->
+                    // there is no need to check whether getNewestPackageVersion returns null, as
+                    // if there is an entry in the map, at least one package will be in the list.
+                    latestPackageVersions.put(pkgName, getNewestPackageVersion(packages))
+    );
+
+    return latestPackageVersions;
+  }
+
+  private boolean hasProvidedPackages(Package pkg) {
+    return pkg.getProvides() != null && pkg.getProvides() instanceof ANDReference && ((ANDReference) pkg.getProvides()).getRefs().length > 0;
+  }
+
+  private Stream<PackageReference> getProvidedPackages(Package pkg) {
+    if (pkg.getProvides() != null && pkg.getProvides() instanceof ANDReference) {
+
+      final PackageReference[] refs = ((ANDReference) pkg.getProvides()).getRefs();
+
+      return Stream.of(refs);
+    }
+
+    return Stream.empty();
+  }
+
+  /**
+   * Constructs a Map containing only the latest versions of the packages.
+   *
+   * @return
+   */
+  private Map<String, Package> getLatestPackageVersions() {
+    final Map<String, List<Package>> groupedByPackageName = getGroupedByPackageName();
+
+    return groupedByPackageName.entrySet().stream()
+            .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> getNewestPackageVersion(e.getValue())
+            ));
+  }
+
+  /**
+   * Selects the newest package version in the given list of packages. This method will not verify
+   * whether or not the package names are all equal. Comparison will be performed solely based on
+   * the package versions
+   *
+   * @param packages a {@link List} of {@link Package packages}
+   * @return the {@link Package} with newest version
+   */
+  private Package getNewestPackageVersion(List<Package> packages) {
+
+    // shortcut: if there is only one single package in the list, there is no need to process the list using a stream
+    if (packages.size() == 1)
+      return packages.get(0);
+
+    final Optional<Package> result = packages.stream().sorted(this::comparePackageVersionDesc).findFirst();
+    if (result.isPresent())
+      return result.get();
+    return null;
+  }
+
+  private Map<String, List<Package>> getGroupedByPackageName() {
+    return packages.stream()
+            .collect(Collectors.groupingBy(Package::getName));
+  }
+
+  @Override
+  public Collection<Package> getPackages() {
+    return packages;
+  }
+
+  @Override
+  public void addPackage(Package newPkg) {
+
+
+    final Iterator<Package> iter = packages.iterator();
+    while (iter.hasNext()) {
+      Package pkg = iter.next();
+      // the existing package has the same name
+
+      if (pkg.getName().equals(newPkg.getName())) {
+        // and the existing package has an older version than the new package
+        if (comparePackageVersionDesc(pkg, newPkg) >= 0) {
+          // remove the existing package and add the new replacement.
+          iter.remove();
+          packages.add(newPkg);
+          return;
+        }
+      }
+    }
+
+    packages.add(newPkg);
+  }
+
+  @Override
+  public void addPackageDontVerifyVersion(Package pkg) {
+    packages.add(pkg);
+  }
+
+  @Override
+  public Package getPackage(String name) {
+    final Optional<Package> result = packages.stream() //
+            .filter(pkg -> pkg.getName().equals(name)) //
+            .sorted(this::comparePackageVersionDesc) //
+            .findFirst();
+    if (result.isPresent())
+      return result.get();
+    return null;
+  }
+
+  @Override
+  public List<Package> getProvidesPackages(String provided) {
+
+    return packages.stream()
+            .filter(pkg -> getProvidedPackages(pkg).anyMatch(ref -> ref.getName().equals(provided)))
+            .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<Package> getDependency(Package pack) {
+
+    return packages.stream()
+            .filter(pkg -> pkg.getDepends().matches(pack) || pkg.getPreDepends().matches(pack))
+            .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean removePackage(Package pkg) {
+    // XXX note: this implementation is due to compatibility reasons with the old serialization db. Currently the version of the package is not taken into account, when deleting an existing package.
+    return packages.removeIf(e -> e.getName().equals(pkg.getName()));
+  }
+
+  public static class MapDBPackageDatabaseFactory implements PackageDatabaseFactory {
+
+    @Override
+    public PackageDatabase create(Path targetPath) throws IOException {
+
+      final DB db = DBMaker
+              .newFileDB(targetPath.toFile())
+              .checksumEnable()
+              .closeOnJvmShutdown()
+              .make();
+
+      final NavigableSet<Package> packages = db.new BTreeSetMaker("packages") //
+              // enabling the counter, as updates will not happen that often, but access will
+              .counterEnable()
+              .makeOrGet();
+
+      return new MapDBPackageDatabase(db, packages);
+
+    }
+  }
+}

--- a/services/package-manager/src/main/java/org/openthinclient/util/dpkg/DPKGPackageFactory.java
+++ b/services/package-manager/src/main/java/org/openthinclient/util/dpkg/DPKGPackageFactory.java
@@ -18,7 +18,7 @@
  * this program; if not, write to the Free Software Foundation, Inc., 59 Temple
  * Place - Suite 330, Boston, MA 02111-1307, USA.
  *******************************************************************************/
-package org.openthinclient.pkgmgr;
+package org.openthinclient.util.dpkg;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/services/package-manager/src/main/java/org/openthinclient/util/dpkg/DPKGPackageManager.java
+++ b/services/package-manager/src/main/java/org/openthinclient/util/dpkg/DPKGPackageManager.java
@@ -21,7 +21,15 @@
 package org.openthinclient.util.dpkg;
 
 import org.apache.commons.io.FileSystemUtils;
-import org.openthinclient.pkgmgr.*;
+import org.openthinclient.pkgmgr.I18N;
+import org.openthinclient.pkgmgr.PackageDatabaseFactory;
+import org.openthinclient.pkgmgr.PackageManager;
+import org.openthinclient.pkgmgr.PackageManagerConfiguration;
+import org.openthinclient.pkgmgr.PackageManagerException;
+import org.openthinclient.pkgmgr.PackageManagerTaskSummary;
+import org.openthinclient.pkgmgr.SourcesList;
+import org.openthinclient.pkgmgr.SourcesListParser;
+import org.openthinclient.pkgmgr.UpdateDatabase;
 import org.openthinclient.pkgmgr.connect.DownloadFiles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -209,17 +217,19 @@ public class DPKGPackageManager implements PackageManager {
 	public org.openthinclient.pkgmgr.PackageDatabase availablePackages;
 	public org.openthinclient.pkgmgr.PackageDatabase archivesDB;
   private final PackageManagerConfiguration configuration;
+	private final PackageDatabaseFactory packageDatabaseFactory;
 
-  public DPKGPackageManager(org.openthinclient.pkgmgr.PackageDatabase availableDB,
-			org.openthinclient.pkgmgr.PackageDatabase removedDB, org.openthinclient.pkgmgr.PackageDatabase installedDB,
-			org.openthinclient.pkgmgr.PackageDatabase archivesDB, PackageManagerConfiguration configuration) throws IOException {
+	public DPKGPackageManager(org.openthinclient.pkgmgr.PackageDatabase availableDB,
+														org.openthinclient.pkgmgr.PackageDatabase removedDB, org.openthinclient.pkgmgr.PackageDatabase installedDB,
+														org.openthinclient.pkgmgr.PackageDatabase archivesDB, PackageManagerConfiguration configuration, PackageDatabaseFactory packageDatabaseFactory) throws IOException {
 		this.installedPackages = installedDB;
 		this.removedDB = removedDB;
 		this.availablePackages = availableDB;
 		this.archivesDB = archivesDB;
     this.configuration = configuration;
+		this.packageDatabaseFactory = packageDatabaseFactory;
 
-    this.installDir = configuration.getInstallDir();
+		this.installDir = configuration.getInstallDir();
     this.archivesDir = configuration.getArchivesDir();
     this.testinstallDir = configuration.getTestinstallDir();
     this.oldInstallDir = configuration.getInstallOldDir();
@@ -1681,7 +1691,7 @@ public class DPKGPackageManager implements PackageManager {
 			// DPKGPackageManager.availablePackages = new UpdateDatabase()
 			// .doUpdate(DPKGPackageManager.this);
 			// availablePackages = new UpdateDatabase().doUpdate(null);
-			availablePackages = new UpdateDatabase(configuration, getSourcesList()).doUpdate(true, taskSummary, configuration.getProxyConfiguration());
+			availablePackages = new UpdateDatabase(configuration, packageDatabaseFactory, getSourcesList()).doUpdate(taskSummary, configuration.getProxyConfiguration());
 			setActprogress(new Double(getActprogress() + getMaxProgress() * 0.5)
 					.intValue());
 			availablePackages.save();

--- a/services/package-manager/src/main/java/org/openthinclient/util/dpkg/DPKGPackageManager.java
+++ b/services/package-manager/src/main/java/org/openthinclient/util/dpkg/DPKGPackageManager.java
@@ -548,31 +548,26 @@ public class DPKGPackageManager implements PackageManager {
 		} finally {
 			lock.writeLock().unlock();
 		}
-		if (filesToDelete != null)
-			if (filesToDelete.size() > 0)
-				for (int n = filesToDelete.size() - 1; n > 0; n--)
-					if (filesToDelete.get(n).isFile())
-						if (!filesToDelete.get(n).delete()) {
-							addWarning(filesToDelete.get(n).getPath()
-									+ I18N.getMessage("interface.notRemove"));
-							logger.error(filesToDelete.get(n).getPath()
-									+ I18N.getMessage("interface.notRemove"));
+		if (filesToDelete.size() > 0)
+			for (int n = filesToDelete.size() - 1; n > 0; n--)
+				if (filesToDelete.get(n).isFile())
+					if (!filesToDelete.get(n).delete()) {
+						addWarning(filesToDelete.get(n).getPath()
+								+ I18N.getMessage("interface.notRemove"));
+						logger.error(filesToDelete.get(n).getPath()
+								+ I18N.getMessage("interface.notRemove"));
+					}
+
+		if (directoriesToDelete.size() > 0)
+			for (int n = directoriesToDelete.size() - 1; n > 0; n--)
+				if (directoriesToDelete.get(n).isDirectory())
+					if (directoriesToDelete.get(n).listFiles().length == 0)
+						if (!directoriesToDelete.get(n).delete()) {
+							addWarning(I18N.getMessage("interface.DirectoryUndeleteable")
+									+ directoriesToDelete.get(n).getName());
+							logger.error(I18N.getMessage("interface.DirectoryUndeleteable")
+									+ directoriesToDelete.get(n).getName());
 						}
-		// throw new PackageManagerException(filesToDelete.get(n).getPath()
-		// + PreferenceStoreHolder.getPreferenceStoreByName("Screen")
-		// .getPreferenceAsString("interface.notRemove",
-		// "No entry found for interface.notRemove"));
-		if (directoriesToDelete != null)
-			if (directoriesToDelete.size() > 0)
-				for (int n = directoriesToDelete.size() - 1; n > 0; n--)
-					if (directoriesToDelete.get(n).isDirectory())
-						if (directoriesToDelete.get(n).listFiles().length == 0)
-							if (!directoriesToDelete.get(n).delete()) {
-								addWarning(I18N.getMessage("interface.DirectoryUndeleteable")
-										+ directoriesToDelete.get(n).getName());
-								logger.error(I18N.getMessage("interface.DirectoryUndeleteable")
-										+ directoriesToDelete.get(n).getName());
-							}
 		// throw new PackageManagerException(PreferenceStoreHolder// .getPreferenceStoreByName("Screen").getPreferenceAsString(// "interface.DirectoryUndeleteable",
 		// "No entry found for interface.DirectoryUndeleteable")
 		// + directoriesToDelete.get(n).getName());
@@ -719,54 +714,22 @@ public class DPKGPackageManager implements PackageManager {
 	 *         the packages on which they depends
 	 */
 	public List<Package> solveDependencies(Collection<Package> installList) {
+
+		// FIXME this implementation is buggy, ugly and should be removed in the future.
+		// there should be something like "compute install plan", returning a summary of
+		// packages should be installed, and/or removed.
+
 		// build a map of PackageReference->List<Packages> requiring said
 		// feature.
 
 		final Map<PackageReference, List<Package>> unsatisfiedDependencies = new HashMap<PackageReference, List<Package>>();
 		for (final Package toBeInstalled : installList) {
-			if (toBeInstalled.getDepends() instanceof ANDReference) {
-				final PackageReference[] dependsPackRef = new PackageReference[((ANDReference) toBeInstalled
-						.getDepends()).getRefs().length];
-				for (int j = 0; j < dependsPackRef.length; j++)
-					dependsPackRef[j] = ((ANDReference) toBeInstalled.getDepends())
-							.getRefs()[j];
-				for (int i = 0; i < dependsPackRef.length; i++)
-					if (dependsPackRef[i] instanceof ORReference) {
-						final PackageReference[] deopendsOrPackRef = new PackageReference[((ORReference) dependsPackRef[i])
-								.getRefs().length];
-						for (int x = 0; x < deopendsOrPackRef.length; x++)
-							deopendsOrPackRef[x] = ((ORReference) dependsPackRef[i])
-									.getRefs()[x];
-						for (int x = 0; x < deopendsOrPackRef.length; x++)
-							addDependency(unsatisfiedDependencies, deopendsOrPackRef[0],
-									toBeInstalled);
+			final PackageReference depends = toBeInstalled.getDepends();
+			final PackageReference preDepends = toBeInstalled.getPreDepends();
 
-					} else
-						addDependency(unsatisfiedDependencies, dependsPackRef[i],
-								toBeInstalled);
-			} else
-				addDependency(unsatisfiedDependencies, toBeInstalled.getDepends(),
-						toBeInstalled);
-			if (toBeInstalled.getPreDepends() instanceof ANDReference) {
-				final PackageReference[] packRef = new PackageReference[((ANDReference) toBeInstalled
-						.getPreDepends()).getRefs().length];
-				for (int j = 0; j < packRef.length; j++)
-					packRef[j] = ((ANDReference) toBeInstalled.getPreDepends()).getRefs()[j];
-				for (int i = 0; i < packRef.length; i++)
-					if (packRef[i] instanceof ORReference) {
-						final PackageReference[] orPackRef = new PackageReference[((ORReference) packRef[i])
-								.getRefs().length];
-						for (int x = 0; x < orPackRef.length; x++)
-							orPackRef[x] = ((ORReference) packRef[i]).getRefs()[x];
-						for (int x = 0; x < orPackRef.length; x++)
-							addDependency(unsatisfiedDependencies, orPackRef[0],
-									toBeInstalled);
+			processPackageReferences(unsatisfiedDependencies, toBeInstalled, depends);
 
-					} else
-						addDependency(unsatisfiedDependencies, packRef[i], toBeInstalled);
-			} else
-				addDependency(unsatisfiedDependencies, toBeInstalled.getPreDepends(),
-						toBeInstalled);
+			processPackageReferences(unsatisfiedDependencies, toBeInstalled, preDepends);
 		}
 		// build map of virtual and non-virtual packages to be installed
 		final Map<String, Package> virtualPackagesToBeInstalled = new HashMap<String, Package>();
@@ -796,12 +759,7 @@ public class DPKGPackageManager implements PackageManager {
 		final ArrayList<Entry<PackageReference, List<Package>>> deps = new ArrayList<Entry<PackageReference, List<Package>>>(
 				unsatisfiedDependencies.entrySet());
 		Collections.sort(deps,
-				new Comparator<Entry<PackageReference, List<Package>>>() {
-					public int compare(Entry<PackageReference, List<Package>> o1,
-							Entry<PackageReference, List<Package>> o2) {
-						return o1.getKey().getName().compareTo(o2.getKey().getName());
-					}
-				});
+						(o1, o2) -> o1.getKey().getName().compareTo(o2.getKey().getName()));
 		final List<Package> ret = new LinkedList<Package>();
 		boolean anotherDependency = false;
 		boolean check = false;
@@ -831,15 +789,13 @@ public class DPKGPackageManager implements PackageManager {
 							anotherDependency = true;
 						}
 					} else {
-						for (int n = 0; n < ret.size(); n++)
-							if (ret.get(n).getName().equalsIgnoreCase(
-									entry.getKey().getName()))
+						for (Package aRet : ret)
+							if (aRet.getName().equalsIgnoreCase(entry.getKey().getName()))
 								check = true;
-						for (int x = 0; x < pack.size(); x++)
-							if (pack.get(x).getName().equalsIgnoreCase(
-									entry.getKey().getName()))
+						for (Package aPack : pack)
+							if (aPack.getName().equalsIgnoreCase(entry.getKey().getName()))
 								check = true;
-						if (check == false) {
+						if (!check) {
 							ret.add(availablePackages.getPackage(entry.getKey().getName()));
 							anotherDependency = true;
 						}
@@ -865,8 +821,24 @@ public class DPKGPackageManager implements PackageManager {
 			return pack;
 	}
 
+	private void processPackageReferences(Map<PackageReference, List<Package>> unsatisfiedDependencies, Package toBeInstalled, PackageReference depends) {
+		if (depends instanceof ANDReference) {
+      final PackageReference[] dependsPackRef = new PackageReference[((ANDReference) depends).getRefs().length];
+      System.arraycopy(((ANDReference) depends).getRefs(), 0, dependsPackRef, 0, dependsPackRef.length);
+      for (PackageReference aDependsPackRef : dependsPackRef)
+        if (aDependsPackRef instanceof ORReference) {
+          final PackageReference[] deopendsOrPackRef = new PackageReference[((ORReference) aDependsPackRef).getRefs().length];
+          System.arraycopy(((ORReference) aDependsPackRef).getRefs(), 0, deopendsOrPackRef, 0, deopendsOrPackRef.length);
+          for (PackageReference aDeopendsOrPackRef : deopendsOrPackRef)
+            addDependency(unsatisfiedDependencies, deopendsOrPackRef[0], toBeInstalled);
+        } else
+          addDependency(unsatisfiedDependencies, aDependsPackRef, toBeInstalled);
+    } else
+      addDependency(unsatisfiedDependencies, depends, toBeInstalled);
+	}
+
 	public void refreshSolveDependencies() {
-		pack.removeAll(pack);
+		pack.clear();
 	}
 
 	/**
@@ -876,15 +848,13 @@ public class DPKGPackageManager implements PackageManager {
 	 * @param r
 	 * @param toBeInstalled
 	 */
-	private void addDependency(
-			Map<PackageReference, List<Package>> unsatisfiedDependencies,
-			PackageReference r, Package toBeInstalled) {
+	private void addDependency(Map<PackageReference, List<Package>> unsatisfiedDependencies, PackageReference r, Package toBeInstalled) {
 		if (!unsatisfiedDependencies.containsKey(r))
-			unsatisfiedDependencies.put(r, new LinkedList<Package>());
+			unsatisfiedDependencies.put(r, new LinkedList<>());
 		unsatisfiedDependencies.get(r).add(toBeInstalled);
 	}
 
-	private final List<Package> packForDelete = new LinkedList<Package>();
+	private final List<Package> packForDelete = new LinkedList<>();
 
 	/**
 	 * will give a List of all Packages which has dependencies on the packages
@@ -894,7 +864,7 @@ public class DPKGPackageManager implements PackageManager {
 	 * @return PackageList with all dependencies and given packages
 	 */
 	public List<Package> isDependencyOf(Collection<Package> packList) {
-		packForDelete.removeAll(packForDelete);
+		packForDelete.clear();
 		return getDependencyOf(packList);
 	}
 
@@ -912,12 +882,9 @@ public class DPKGPackageManager implements PackageManager {
 		} finally {
 			lock.readLock().unlock();
 		}
-		conflicts.addAll(findConflicts(existingPackages, packList,
-				PackagingConflict.Type.CONFLICT_EXISTING));
-		conflicts.addAll(findConflicts(packList, existingPackages,
-				PackagingConflict.Type.CONFLICT_NEW));
-		conflicts.addAll(findConflicts(packList, packList,
-				PackagingConflict.Type.CONFLICT_WITHIN));
+		conflicts.addAll(findConflicts(existingPackages, packList, PackagingConflict.Type.CONFLICT_EXISTING));
+		conflicts.addAll(findConflicts(packList, existingPackages, PackagingConflict.Type.CONFLICT_NEW));
+		conflicts.addAll(findConflicts(packList, packList, PackagingConflict.Type.CONFLICT_WITHIN));
 		if (conflicts.size() > 0)
 			return conflicts.toString();
 		else
@@ -934,7 +901,7 @@ public class DPKGPackageManager implements PackageManager {
 	 */
 	private Collection<PackagingConflict> findConflicts(Collection<Package> l1,
 			Collection<Package> l2, PackagingConflict.Type type) {
-		final Collection<PackagingConflict> conflicts = new ArrayList<PackagingConflict>();
+		final Collection<PackagingConflict> conflicts = new ArrayList<>();
 		for (final Package p1 : l1)
 			for (final Package p2 : l2)
 				if (p1 != p2 && p1.getConflicts().matches(p2))
@@ -961,7 +928,7 @@ public class DPKGPackageManager implements PackageManager {
 		}
 
 		installable.removeAll(installed);
-		installed.removeAll(installed);
+		installed.clear();
 		return installable;
 	}
 
@@ -971,9 +938,9 @@ public class DPKGPackageManager implements PackageManager {
 		lock.readLock().lock();
 		try {
 			if (null == installedPackages.getPackages())
-				ret = new ArrayList<Package>(Collections.EMPTY_LIST);
+				ret = new ArrayList<>(Collections.EMPTY_LIST);
 			else
-				ret = new ArrayList<Package>(installedPackages.getPackages());
+				ret = new ArrayList<>(installedPackages.getPackages());
 			return ret;
 		} finally {
 			lock.readLock().unlock();
@@ -982,7 +949,7 @@ public class DPKGPackageManager implements PackageManager {
 
 	@SuppressWarnings("unchecked")
 	public Collection<Package> getUpdateablePackages() {
-		ArrayList<Package> update = new ArrayList<Package>();
+		ArrayList<Package> update = new ArrayList<>();
 		lock.readLock().lock();
 		try {
 			for (final Package pkg : installedPackages.getPackages()) {
@@ -996,7 +963,7 @@ public class DPKGPackageManager implements PackageManager {
 			lock.readLock().unlock();
 		}
 		if (update.size() < 1)
-			update = new ArrayList<Package>(Collections.EMPTY_LIST);
+			update = new ArrayList<>(Collections.EMPTY_LIST);
 		return update;
 	}
 
@@ -1037,15 +1004,11 @@ public class DPKGPackageManager implements PackageManager {
 			throws IOException, PackageManagerException {
 		boolean ret = false;
 		if (downloadable.size() > 0) {
-			downloadable = new ArrayList<Package>(checkIfFilesAreInDatabase(/* packdb, */
-			downloadable));
+			downloadable = new ArrayList<>(checkIfFilesAreInDatabase(downloadable));
 			final String conflictString = findConflicts(downloadable);
 			if (conflictString != "") {
-				addWarning(I18N.getMessage(
-								"DPKGPackageManager.downloadPackages.conflicts"));
-				logger
-						.error(I18N.getMessage(
-										"DPKGPackageManager.downloadPackages.conflicts"));
+				addWarning(I18N.getMessage("DPKGPackageManager.downloadPackages.conflicts"));
+				logger.error(I18N.getMessage("DPKGPackageManager.downloadPackages.conflicts"));
 			}
 			// throw new PackageManagerException("conflicts existing");
 			else if (downloadable.size() > 0) {
@@ -1064,7 +1027,7 @@ public class DPKGPackageManager implements PackageManager {
 						lock.writeLock().lock();
 						try {
 							for (final Package pkg : downloadable) {
-								Package pack = null;
+								Package pack;
 								if (archivesDB.isPackageInstalledDontVerifyVersion(pkg
 										.getName())) {
 									if (!archivesDB.getPackage(pkg.getName()).getVersion()
@@ -1092,29 +1055,21 @@ public class DPKGPackageManager implements PackageManager {
 							lock.writeLock().unlock();
 						}
 					} else {
-						addWarning(I18N.getMessage(
-										"DPKGPackageManager.downloadPackages.MD5Failed"));
-						logger
-								.error(I18N.getMessage(
-												"DPKGPackageManager.downloadPackages.MD5Failed"));
+						addWarning(I18N.getMessage("DPKGPackageManager.downloadPackages.MD5Failed"));
+						logger.error(I18N.getMessage("DPKGPackageManager.downloadPackages.MD5Failed"));
 					}
 					// throw new PackageManagerException(
 					// "there are some difference while downloading packgaes");
 				} else {
-					downloadable.removeAll(downloadable);
+					downloadable.clear();
 					throw new PackageManagerException(I18N.getMessage("interface.notEnoughtSpaceOnDisk"));
 				}
 			} else {
-				addWarning(I18N.getMessage(
-								"DPKGPackageManager.downloadPackages.fileSizeNull"));
-				logger
-						.error(I18N.getMessage(
-										"DPKGPackageManager.downloadPackages.fileSizeNull"));
+				addWarning(I18N.getMessage("DPKGPackageManager.downloadPackages.fileSizeNull"));
+				logger.error(I18N.getMessage("DPKGPackageManager.downloadPackages.fileSizeNull"));
 			}
-			// throw new PackageManagerException("BAD'!!!!!! files are
-			// terrible111111");
 		}
-		downloadable.removeAll(downloadable);
+		downloadable.clear();
 		maxVolumeinByte = 0;
 
 		return ret;
@@ -1123,17 +1078,15 @@ public class DPKGPackageManager implements PackageManager {
 
 	public boolean update(Collection<Package> oldPacks)
 			throws PackageManagerException {
-		boolean ret = false;
-		final ArrayList<Package> newPacks = new ArrayList<Package>();
+		final ArrayList<Package> newPacks = new ArrayList<>();
 		if (oldPacks.size() > 0) {
 			lock.readLock().lock();
 			try {
 				for (final Package pkg : oldPacks)
 					newPacks.add(availablePackages.getPackage(pkg.getName()));
 				if (downloadPackages(newPacks)) {
-					ret = true;
 					setActprogress(maxProgress);
-					return ret;
+					return true;
 				}
 			} catch (final IOException e) {
 				addWarning(e.toString());
@@ -1144,16 +1097,15 @@ public class DPKGPackageManager implements PackageManager {
 		}
 		setActprogress(maxProgress);
 		setIsDoneTrue();
-		return ret;
+		return false;
 	}
 
 	/**
-	 * 
+	 *
 	 * @param downloadable
 	 * @return List of all given packages which are not in the installed database
 	 */
-	private ArrayList<Package> checkIfFilesAreInDatabase(
-			ArrayList<Package> downloadable) {
+	private ArrayList<Package> checkIfFilesAreInDatabase(ArrayList<Package> downloadable) {
 		lock.readLock().lock();
 		try {
 			for (int i = 0; i < downloadable.size(); i++)
@@ -1169,10 +1121,10 @@ public class DPKGPackageManager implements PackageManager {
 			throws PackageManagerException {
 		boolean ret = false;
 		try {
-			if (downloadPackages(new ArrayList<Package>(installList)))
+			if (downloadPackages(new ArrayList<>(installList)))
 				ret = true;
-			installList.removeAll(installList);
-			pack.removeAll(pack);
+			installList.clear();
+			pack.clear();
 
 		} catch (final Exception e) {
 			addWarning(e.toString());
@@ -1198,11 +1150,10 @@ public class DPKGPackageManager implements PackageManager {
 			final int fileProg = packageProg / p.getFileList().size();
 			for (final File f : p.getFileList()) {
 				if (!new File(path, f.getPath()).delete()) {
-					addWarning(I18N.getMessage("PackageManagerBean.doNFSmove.couldNotRemove")
-							+ " " + new File(path, f.getPath()).getAbsolutePath());
-					logger
-							.error(I18N.getMessage("PackageManagerBean.doNFSmove.couldNotRemove")
-									+ " " + new File(path, f.getPath()).getAbsolutePath());
+					final String msg = I18N.getMessage("PackageManagerBean.doNFSmove.couldNotRemove")
+									+ " " + new File(path, f.getPath()).getAbsolutePath();
+					addWarning(msg);
+					logger.error(msg);
 				}
 				// throw new PackageManagerException(
 				// PreferenceStoreHolder// .getPreferenceStoreByName("screen")// .getPreferenceAsString(
@@ -1241,13 +1192,10 @@ public class DPKGPackageManager implements PackageManager {
 			return Collections.EMPTY_LIST;
 		lock.readLock().lock();
 		try {
-			if (removedDB.getPackages() == null
-					|| removedDB.getPackages().size() == 0)
+			if (removedDB.getPackages() == null || removedDB.getPackages().size() == 0)
 				return Collections.EMPTY_LIST;
 			else {
-				final ArrayList<Package> deletePackages = new ArrayList<Package>(
-						removedDB.getPackages());
-				return deletePackages;
+				return new ArrayList<>(removedDB.getPackages());
 			}
 		} finally {
 			lock.readLock().unlock();

--- a/services/package-manager/src/main/java/org/openthinclient/util/dpkg/DPKGPackageManager.java
+++ b/services/package-manager/src/main/java/org/openthinclient/util/dpkg/DPKGPackageManager.java
@@ -21,14 +21,7 @@
 package org.openthinclient.util.dpkg;
 
 import org.apache.commons.io.FileSystemUtils;
-import org.openthinclient.pkgmgr.I18N;
-import org.openthinclient.pkgmgr.PackageManager;
-import org.openthinclient.pkgmgr.PackageManagerConfiguration;
-import org.openthinclient.pkgmgr.PackageManagerException;
-import org.openthinclient.pkgmgr.PackageManagerTaskSummary;
-import org.openthinclient.pkgmgr.SourcesList;
-import org.openthinclient.pkgmgr.SourcesListParser;
-import org.openthinclient.pkgmgr.UpdateDatabase;
+import org.openthinclient.pkgmgr.*;
 import org.openthinclient.pkgmgr.connect.DownloadFiles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +33,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -212,15 +204,15 @@ public class DPKGPackageManager implements PackageManager {
 		}
 	}
 
-	public PackageDatabase installedPackages;
-	public PackageDatabase removedDB;
-	public PackageDatabase availablePackages;
-	public PackageDatabase archivesDB;
+	public org.openthinclient.pkgmgr.PackageDatabase installedPackages;
+	public org.openthinclient.pkgmgr.PackageDatabase removedDB;
+	public org.openthinclient.pkgmgr.PackageDatabase availablePackages;
+	public org.openthinclient.pkgmgr.PackageDatabase archivesDB;
   private final PackageManagerConfiguration configuration;
 
-  public DPKGPackageManager(PackageDatabase availableDB,
-			PackageDatabase removedDB, PackageDatabase installedDB,
-			PackageDatabase archivesDB, PackageManagerConfiguration configuration) throws IOException {
+  public DPKGPackageManager(org.openthinclient.pkgmgr.PackageDatabase availableDB,
+			org.openthinclient.pkgmgr.PackageDatabase removedDB, org.openthinclient.pkgmgr.PackageDatabase installedDB,
+			org.openthinclient.pkgmgr.PackageDatabase archivesDB, PackageManagerConfiguration configuration) throws IOException {
 		this.installedPackages = installedDB;
 		this.removedDB = removedDB;
 		this.availablePackages = availableDB;

--- a/services/package-manager/src/main/java/org/openthinclient/util/dpkg/PackageDatabase.java
+++ b/services/package-manager/src/main/java/org/openthinclient/util/dpkg/PackageDatabase.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.openthinclient.pkgmgr.I18N;
-import org.openthinclient.pkgmgr.PackageManagerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +54,7 @@ import org.slf4j.LoggerFactory;
  * 
  * @author levigo
  */
-public class PackageDatabase implements Serializable {
+public class PackageDatabase implements Serializable, org.openthinclient.pkgmgr.PackageDatabase {
 	private static final long serialVersionUID = 3761126046166234677L;
 
 	private static final Logger logger = LoggerFactory.getLogger(PackageDatabase.class);
@@ -241,7 +240,7 @@ public class PackageDatabase implements Serializable {
 	 * @return a PackageDatabase with which the different methods could be made
 	 * @throws IOException
 	 */
-	public static PackageDatabase open(File databaseLocation) throws IOException {
+	public static org.openthinclient.pkgmgr.PackageDatabase open(File databaseLocation) throws IOException {
 		final File databaseDirectory = databaseLocation.getParentFile();
 		
 		if (!databaseDirectory.canWrite())
@@ -290,6 +289,7 @@ public class PackageDatabase implements Serializable {
 	 * 
 	 * @throws IOException
 	 */
+	@Override
 	public void save() throws IOException {
 		final ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(
 				location));
@@ -300,6 +300,7 @@ public class PackageDatabase implements Serializable {
 	/**
 	 * Close the package database (without saving it!)
 	 */
+	@Override
 	public void close() {
 
 		logger.info("PackageDatabase at " + location + " closed");
@@ -321,6 +322,7 @@ public class PackageDatabase implements Serializable {
 	 * @param name
 	 * @return TRUE ONLY if the package is saved in the database otherwise FALSE
 	 */
+	@Override
 	public boolean isPackageInstalled(String name) {
 		return getProvidedPackages().containsKey(name);
 	}
@@ -330,6 +332,7 @@ public class PackageDatabase implements Serializable {
 	 * @param name
 	 * @return TRUE ONLY if the package is saved in the database otherwise FALSE
 	 */
+	@Override
 	public boolean isPackageInstalledDontVerifyVersion(String name) {
 		if (null == getPackage(name))
 			return false;
@@ -343,6 +346,7 @@ public class PackageDatabase implements Serializable {
 	 * 
 	 * @return
 	 */
+	@Override
 	public Map<String, Package> getProvidedPackages() {
 		// lazy initialization of virtual package map
 		if (null == providedPackages) {
@@ -365,6 +369,7 @@ public class PackageDatabase implements Serializable {
 	 * 
 	 * @return a collection of all packagtes which are isaved in the database
 	 */
+	@Override
 	@SuppressWarnings("unchecked")
 	public Collection<Package> getPackages() {
 		if (null == packages)
@@ -403,6 +408,7 @@ public class PackageDatabase implements Serializable {
 	 * 
 	 * @param pkg
 	 */
+	@Override
 	public void addPackage(Package pkg) {
 		if (null == packages)
 			packages = new ArrayList<Package>();
@@ -423,6 +429,7 @@ public class PackageDatabase implements Serializable {
 	 * 
 	 * @param pkg
 	 */
+	@Override
 	public void addPackageDontVerifyVersion(Package pkg) {
 		if (null == packages)
 			packages = new ArrayList<Package>();
@@ -443,6 +450,7 @@ public class PackageDatabase implements Serializable {
 	 * @param name
 	 * @return the Package which has the given name
 	 */
+	@Override
 	public Package getPackage(String name) {
 		if (packages == null)
 			return null;
@@ -460,6 +468,7 @@ public class PackageDatabase implements Serializable {
 	 * @return a list of Packages which are Providing these package given as
 	 *         String
 	 */
+	@Override
 	public List<Package> getProvidesPackages(String provided) {
 		final List<Package> providePackages = new LinkedList<Package>();
 		for (int i = 0; i < packages.size(); i++)
@@ -476,6 +485,7 @@ public class PackageDatabase implements Serializable {
 	 * @param pack
 	 * @return a list of Packages which are dependency of the given Package pack
 	 */
+	@Override
 	public List<Package> getDependency(Package pack) {
 		final ArrayList<Package> remove = new ArrayList<Package>();
 		for (final Package pkg : packages) {
@@ -492,6 +502,7 @@ public class PackageDatabase implements Serializable {
 	 * @param pkg
 	 * @return TRUE only if the remove was accomplished otherwise FALSE
 	 */
+	@Override
 	public boolean removePackage(Package pkg) {
 		final Package pack = getPackage(pkg.getName());
 		boolean b = false;

--- a/services/package-manager/src/test/java/org/openthinclient/pkgmgr/impl/AbstractPackageDatabaseTestBase.java
+++ b/services/package-manager/src/test/java/org/openthinclient/pkgmgr/impl/AbstractPackageDatabaseTestBase.java
@@ -1,0 +1,256 @@
+package org.openthinclient.pkgmgr.impl;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.openthinclient.pkgmgr.PackageDatabase;
+import org.openthinclient.pkgmgr.PackageDatabaseFactory;
+import org.openthinclient.util.dpkg.*;
+import org.openthinclient.util.dpkg.Package;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public abstract class AbstractPackageDatabaseTestBase {
+
+  private final PackageDatabaseFactory packageDatabaseFactory;
+
+  public AbstractPackageDatabaseTestBase(PackageDatabaseFactory packageDatabaseFactory) {
+    this.packageDatabaseFactory = packageDatabaseFactory;
+  }
+
+  @Test
+  public void testCreateNewDatabaseAndSingleEntry() throws Exception {
+
+    final Path tempFile = createTemporaryFile();
+
+    PackageDatabase database = packageDatabaseFactory.create(tempFile);
+
+    assertEquals(0, database.getPackages().size());
+
+    database.addPackage(createSamplePackage("foo", "2.0-1"));
+
+    assertEquals(1, database.getPackages().size());
+    database.save();
+    database.close();
+
+    // reopen the package database
+    database = packageDatabaseFactory.create(tempFile);
+
+    assertEquals(1, database.getPackages().size());
+  }
+
+  @Test
+    public void testAddPackageInDifferentVersions() throws Exception {
+
+    final Path tempFile = createTemporaryFile();
+
+    PackageDatabase database = packageDatabaseFactory.create(tempFile);
+
+    database.addPackage(createSamplePackage("foo", "1.0-1"));
+
+    assertEquals(1, database.getPackages().size());
+
+    database.addPackage(createSamplePackage("foo", "1.0-2"));
+
+    assertEquals(1, database.getPackages().size());
+
+    assertEquals(new Version("1.0-2"), database.getPackages().iterator().next().getVersion());
+  }
+
+
+  @Test
+  public void testAddAndRemovePackages() throws Exception {
+
+    final Path tempFile = createTemporaryFile();
+
+    PackageDatabase database = packageDatabaseFactory.create(tempFile);
+
+    database.addPackageDontVerifyVersion(createSamplePackage("foo", "1.0-1"));
+
+    assertEquals(1, database.getPackages().size());
+
+    // FIXME the existing serialization DB behaves this way, BUT THAT FEELS JUST WRONG!
+    // when providing a package object, only the appropriate version should be deleted!
+    database.removePackage(createSamplePackage("foo", "1.0-2"));
+
+    assertEquals(0, database.getPackages().size());
+  }
+
+
+  @Test
+  public void testAddPackageDontVerifyVersionInDifferentVersions() throws Exception {
+
+    final Path tempFile = createTemporaryFile();
+
+    PackageDatabase database = packageDatabaseFactory.create(tempFile);
+
+    database.addPackageDontVerifyVersion(createSamplePackage("foo", "1.0-1"));
+
+    assertEquals(1, database.getPackages().size());
+
+    database.addPackageDontVerifyVersion(createSamplePackage("foo", "1.0-2"));
+
+    assertEquals(2, database.getPackages().size());
+  }
+
+  // FIXME this is too stupid! The serialization db DOES check the version,
+  // but only adds new packages if the given package is newer than the existing.
+  @Ignore
+  @Test
+  public void testAddPackageDontVerifyVersionInDifferentVersionsNewerVersionFirst() throws Exception {
+
+    final Path tempFile = createTemporaryFile();
+
+    PackageDatabase database = packageDatabaseFactory.create(tempFile);
+
+    database.addPackageDontVerifyVersion(createSamplePackage("foo", "1.0-2"));
+
+    assertEquals(1, database.getPackages().size());
+
+    database.addPackageDontVerifyVersion(createSamplePackage("foo", "1.0-1"));
+
+    assertEquals(2, database.getPackages().size());
+  }
+
+  @Test
+  public void testCreateDatabaseWithManyEntries() throws Exception {
+
+    final PackageDatabase database = createDatabaseWithSampleData();
+
+    database.getPackages().stream().map(e->e.getName() + " " + e.getVersion()).forEach(System.err::println);
+
+    // the all packages lists contains packages with the same name but different versions
+    assertEquals(23, database.getPackages().size());
+
+    // as the provided packages are represented within a map, only one single version is made available.
+    assertEquals(21, database.getProvidedPackages().size());
+  }
+
+  @Test
+  public void testDatabaseGetPackage() throws Exception {
+
+    final PackageDatabase database = createDatabaseWithSampleData();
+
+    final org.openthinclient.util.dpkg.Package tcosPackage = database.getPackage("tcos-libs");
+
+    assertNotNull(tcosPackage);
+    assertEquals(new Version("2.0-14"), tcosPackage.getVersion());
+
+  }
+
+  @Test
+  public void testDatabaseGetProvidesPackage() throws Exception {
+
+    final PackageDatabase database = createDatabaseWithSampleData();
+
+    final List<Package> packages = database.getProvidesPackages("ica-client");
+
+    assertNotNull(packages);
+    assertEquals(1, packages.size());
+
+    assertEquals("ica-client-12", packages.get(0).getName());
+
+
+    assertEquals(0, database.getProvidesPackages("non-existing").size());
+
+  }
+
+  // FIXME this test doesn't work at all. The existing serialization DB somehow seems to work even with a broken implementation
+  @Ignore
+  @Test
+  public void testDatabaseGetDependency() throws Exception {
+
+    final PackageDatabase database = createDatabaseWithSampleData();
+
+    final List<Package> packages = database.getDependency(database.getPackage("remote-connect"));
+
+    assertNotNull(packages);
+    assertEquals(1, packages.size());
+
+    assertEquals("base", packages.get(0).getName());
+
+
+    assertEquals(0, database.getDependency(database.getPackage("openthinclient-server-tftp")).size());
+
+  }
+
+  @Test
+  public void testGetProvidedPackages() throws Exception {
+
+    final PackageDatabase database = createDatabaseWithSampleData();
+
+    final Map<String, org.openthinclient.util.dpkg.Package> providedPackages = database.getProvidedPackages();
+
+    assertEquals(21, providedPackages.size());
+
+    verifyPackage(providedPackages, "base", new Version("2.0-25"));
+    verifyPackage(providedPackages, "cmdline", new Version("2.0-01"));
+    verifyPackage(providedPackages, "cups-client", new Version("2.0-2"));
+    verifyPackage(providedPackages, "desktop", new Version("2.0-15"));
+    verifyPackage(providedPackages, "freerdp-git", new Version("2.0-1.2-12"));
+    verifyPackage(providedPackages, "ica-client-12", new Version("2.0-12.1-13"));
+    verifyPackage(providedPackages, "openthinclient-manager", new Version("1.0.2-1"));
+    verifyPackage(providedPackages, "openthinclient-server-dhcp", new Version("1.0.0-1"));
+    verifyPackage(providedPackages, "openthinclient-server-ldap", new Version("1.0.0-1"));
+    verifyPackage(providedPackages, "openthinclient-server-nfs", new Version("1.0.0-1"));
+    verifyPackage(providedPackages, "openthinclient-server-syslog", new Version("1.0.0-1"));
+    verifyPackage(providedPackages, "openthinclient-server-tftp", new Version("1.0.0-1"));
+    verifyPackage(providedPackages, "printserver", new Version("2.0-3"));
+    verifyPackage(providedPackages, "rdesktop", new Version("2.0-1.8.2-4"));
+    verifyPackage(providedPackages, "remote-connect", new Version("2.0-10"));
+    verifyPackage(providedPackages, "smartcard-lite", new Version("2.0-2"));
+    verifyPackage(providedPackages, "sso-tcos", new Version("2.0-4"));
+    // FIXME the following lines would contain checks with the newest version but the serialization DB doesn't provide the lastest packages only
+//    verifyPackage(providedPackages, "tcos-devices", new Version("2.0-20"));
+//    verifyPackage(providedPackages, "tcos-libs", new Version("2.0-14"));
+//    verifyPackage(providedPackages, "tcos-scripts", new Version("2.0-40"));
+
+  }
+
+  private void verifyPackage(Map<String, Package> providedPackages, String packageName, Version version) {
+
+    final Package pkg = providedPackages.get(packageName);
+    assertNotNull(pkg);
+
+    assertEquals(packageName, pkg.getName());
+    assertEquals(version, pkg.getVersion());
+
+  }
+
+  private PackageDatabase createDatabaseWithSampleData() throws IOException {
+    final Path tempFile = createTemporaryFile();
+
+    final PackageDatabase database = packageDatabaseFactory.create(tempFile);
+
+    final DPKGPackageFactory dpkgPackageFactory = new DPKGPackageFactory(null);
+    final List<org.openthinclient.util.dpkg.Package> packages = dpkgPackageFactory.getPackage(getClass().getResourceAsStream("/2015-05-15_manager-rolling-Packages.txt"));
+
+    packages.forEach(database::addPackage);
+    return database;
+  }
+
+  private Path createTemporaryFile() throws IOException {
+    final Path tempFile = Files.createTempFile("otc-test-db", ".db");
+
+    // the temporary fill will be created upon the call above.
+    // As the old implementation expects no such file, when there is no existing database,
+    // we're deleting the temporary file here.
+    Files.delete(tempFile);
+    return tempFile;
+  }
+
+
+  private DPKGPackage createSamplePackage(String name, String version) {
+    final DPKGPackage pkg = new DPKGPackage(null);
+    pkg.setName(name);
+    pkg.setVersion(version);
+    pkg.setProvides(new ANDReference(""));
+    return pkg;
+  }
+}

--- a/services/package-manager/src/test/java/org/openthinclient/pkgmgr/impl/MapDBPackageDatabaseTest.java
+++ b/services/package-manager/src/test/java/org/openthinclient/pkgmgr/impl/MapDBPackageDatabaseTest.java
@@ -1,0 +1,7 @@
+package org.openthinclient.pkgmgr.impl;
+
+public class MapDBPackageDatabaseTest extends AbstractPackageDatabaseTestBase {
+  public MapDBPackageDatabaseTest() {
+    super(new MapDBPackageDatabase.MapDBPackageDatabaseFactory());
+  }
+}

--- a/services/package-manager/src/test/java/org/openthinclient/pkgmgr/impl/SerializationPackageDatabaseTest.java
+++ b/services/package-manager/src/test/java/org/openthinclient/pkgmgr/impl/SerializationPackageDatabaseTest.java
@@ -1,0 +1,9 @@
+package org.openthinclient.pkgmgr.impl;
+
+import org.openthinclient.util.dpkg.PackageDatabase;
+
+public class SerializationPackageDatabaseTest  extends AbstractPackageDatabaseTestBase {
+  public SerializationPackageDatabaseTest() {
+    super(new PackageDatabase.SerializationPackageDatabaseFactory());
+  }
+}

--- a/services/package-manager/src/test/java/org/openthinclient/util/dpkg/DPKGPackageFactoryTest.java
+++ b/services/package-manager/src/test/java/org/openthinclient/util/dpkg/DPKGPackageFactoryTest.java
@@ -1,0 +1,30 @@
+package org.openthinclient.util.dpkg;
+
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class DPKGPackageFactoryTest {
+
+  @Test
+  public void testParsePackages() throws Exception {
+
+    final InputStream packagesStream = getClass().getResourceAsStream("/test-repository/Packages");
+    assertNotNull(packagesStream);
+
+    final DPKGPackageFactory factory = new DPKGPackageFactory(null);
+    final List<Package> packages = factory.getPackage(packagesStream);
+
+    assertEquals(4, packages.size());
+
+    assertEquals("foo", packages.get(0).getName());
+    assertEquals("zonk", packages.get(1).getName());
+    assertEquals("bar2", packages.get(2).getName());
+    assertEquals("bar", packages.get(3).getName());
+
+
+  }
+}

--- a/services/package-manager/src/test/resources/2015-05-15_manager-rolling-Packages.txt
+++ b/services/package-manager/src/test/resources/2015-05-15_manager-rolling-Packages.txt
@@ -1,0 +1,646 @@
+Package: tcos-devices
+Priority: optional
+Section: admin
+Installed-Size: 196
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-20
+Conflicts: openthinclient-schema
+Filename: ./tcos-devices_2.0-20_i386.deb
+Size: 25112
+MD5sum: b3c259e58b3747df8140d6d9b39d9609
+SHA1: 0ca9cb3b94e1d777960625d06cfce362d8dbbbd1
+SHA256: ff4760542bc7af2b77e961657724336012d9f56798a83d06ba4f5ed798e0b2d8
+SHA512: d63b31a7bf5e901b2953b1220977202d5a655fff361ef9c5255e21e36469760cf475a180f0c40039b99c75d9bf62af5bb3b5da5402840a69642718efb6b5e217
+Description: Schemas for openthinclient manager
+ Several XML files for devices like displays.
+
+Package: tcos-libs
+Priority: optional
+Section: unknown
+Installed-Size: 32
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-14
+Conflicts: python-tcos
+Filename: ./tcos-libs_2.0-14_i386.deb
+Size: 14512
+MD5sum: 1f167f176a186e52ed4b10bf077a94ff
+SHA1: 4af41d786b7ecd818333b4df80563f1ff10068cb
+SHA256: d3057343288bf138f8e55e8deb18e1bf58f6df7161b3a55474a6d98ea8aa95a4
+SHA512: 8ba1ef6112fe04cf0a35261e5257c683a11041099b61af6879335d641b3e07bf7c337196fdedff1f5075f05e0aceed9d6f55ea182dec01357429430e0dd4cbc6
+Description: python libraries for openthinclient
+ This libraries are used by the launchers and and other
+ scripts doing the magic inside a running client.
+
+Package: freerdp-git
+Priority: optional
+Section: x11
+Installed-Size: 1556
+Maintainer: Joern Frenzel <j.frenzel@openthinclient.com>
+Architecture: i386
+Version: 2.0-1.2-09
+Depends: base (>= 2.0-25)
+Filename: ./freerdp-git_2.0-1.2-09_i386.deb
+Size: 1547246
+MD5sum: 23f938f03a5ad0a4a461693ca0a7a35c
+SHA1: 8f57563066e3ebf0de8dd179250d5944bf21bd7b
+SHA256: ee36e211ac778317b4ef85b5181400f5cfca2d86c27aa0f176150760dc43b64d
+SHA512: e8e065ba1a01ce3d1074a1d2766a0909f8ecc93c73f3b93e5ab23c5e15913aed218c2935df2deab29700a10dbe123303d9d7e725617b482047d016f47ed3f480
+Description: RDP client for Windows Terminal Services (GIT version)
+ FreeRDP is a client for Windows Terminal Services implementing the Remote
+ Desktop Protocol (RDP).
+ .
+ Currently, the following Windows Versions are supported:
+ .
+  * Windows NT Server
+  * Windows 2000 Terminal Server
+  * Windows XP
+  * Windows 2003 Server
+  * Windows Vista
+  * Windows 2008 Server
+  * Windows 7
+ .
+ Homepage: http://www.freerdp.com/
+ Homepage: http://openthinclientalliance.org/
+
+Package: remote-connect
+Priority: optional
+Section: unknown
+Installed-Size: 31
+Maintainer: Joern Frenzel <j.frenzel@openthinclient.com>
+Architecture: i386
+Version: 2.0-10
+Depends: base
+Filename: ./remote-connect_2.0-10_i386.deb
+Size: 3480
+MD5sum: dcce0e7b2f3ee3a634e7c1663b7074a2
+SHA1: b4013cc6b2f03a5318b1275af519302ff037832c
+SHA256: 1e9e8e607dde21c4f6526a1a8c28e4a950541b32aecf19609b3700270ffe0611
+SHA512: bfe69af406046e5aaaaf1a6d246dfaf994b177c941f2f37b1830d91ddbde085e36cc63b28ba5b6eef643c399d348c554cb944591ad1fc39538cfa8c1eda4391f
+Description: allows VNC remote view
+ This packages allows VNC remote view on the client. A password
+ file is generated on the fly. The user can be asked to allow
+ connections and can be allowed to disconnect sessions.
+ Thanks to Karl Runge.
+ See: http://www.karlrunge.com/x11vnc/
+
+Package: openthinclient-server-tftp
+Priority: required
+Section: net
+Installed-Size: 3464
+Maintainer: Simon Tobies <s.tobies@openthinclient.com>
+Architecture: i386
+Version: 1.0.0-1
+Depends: openthinclient-server-ldap
+Filename: ./openthinclient-server-tftp_1.0.0-1_i386.deb
+Size: 3521378
+MD5sum: 483e145c76d538df32538718314efe71
+SHA1: 3a1283858d12928dd19a9242442151b78a8df127
+SHA256: 372ffbb24030e107f7aa828052e4d75e018a0acfe5201ccd69b5f091ccc5b06d
+SHA512: a482f10fc86b2e15c5ae23e51f93fa4896a83f9d6fd5a2bf0878c2cf93d24857b4febbf1b773c83789fa7ef6aff7d5d549daa64abc755f5ba45081aebbaf12ac
+Description: OpenThinClient TFTP Server
+ The "OpenThinClient TFTP Server" is a server which supports the Internet
+ Trivial File Transfer Protocol. It is reposible for providing kernel and
+ initrd for ThinClients booting via PXE.
+ .
+ It is build as a "Service Archive" (SAR) to be deployed by the JBoss
+ Application Server.
+
+Package: openthinclient-manager
+Priority: optional
+Section: admin
+Installed-Size: 33328
+Maintainer: Simon Tobies <s.tobies@openthinclient.com>
+Architecture: i386
+Version: 1.0.0-2
+Depends: openthinclient-server-ldap
+Filename: ./openthinclient-manager_1.0.0-2_i386.deb
+Size: 34078796
+MD5sum: 52a4b29bb8d86dd2502ee2db7481add1
+SHA1: 8455a44a64e09fa2522949455a76aaa421e56ebb
+SHA256: ccaf16610ec68c0b851932f76fad7c9eb0a993f8f5369168f8fdc939f229f08d
+SHA512: ac272f5ab00fac2b2d8ed086840937f24ba3e8c78de135248158891645dd6961b9d9f8cf294bab5fd25577390dae318749e8f43a283c007dcf80105e23904886
+Description: OpenThinClient Manager
+ The "OpenThinClient Manager" provides a powerful, Java-based graphical user
+ interface to manage all aspects of the ThinClients under its control.
+ Furthermore, it supports integration with enterprise-wide management
+ environments like LDAP or MS ADS.
+ .
+ It is build as an "Enterprise Archive" (EAR) containing various modules to be
+ deployed by the JBoss Application Server.
+
+Package: openthinclient-server-syslog
+Priority: important
+Section: net
+Installed-Size: 40
+Maintainer: Simon Tobies <s.tobies@openthinclient.com>
+Architecture: i386
+Version: 1.0.0-1
+Filename: ./openthinclient-server-syslog_1.0.0-1_i386.deb
+Size: 26078
+MD5sum: 78cbe8401bd7acd0bf92e0de723ede82
+SHA1: 033c216a2f9e41cc4a274897b3b683fd6efdb14c
+SHA256: e7a06801c6ba193bdbfc90aa9f4ff904e46de959b92fb473c6a57432bb464036
+SHA512: 46d00e094bdef39c56b1ef73af64ac08b09e6b57796fe0608536c0e4a2b7651cb771ed3d383f8966f82c379c9925e83aa5b12effda6f194575e71a73460e7387
+Description: OpenThinClient Syslog Server
+ The "OpenThinClient Syslog Server" implements a system log daemon.
+ It is responsible for providing logging of messages received from programs
+ and facilities from remote ThinClients.
+ .
+ It is build as a "Service Archive" (SAR) to be deployed by the JBoss
+ Application Server.
+
+Package: freerdp-git
+Priority: optional
+Section: x11
+Installed-Size: 1553
+Maintainer: Joern Frenzel <j.frenzel@openthinclient.com>
+Architecture: i386
+Version: 2.0-1.2-12
+Depends: base (>= 2.0-25)
+Filename: ./freerdp-git_2.0-1.2-12_i386.deb
+Size: 1547828
+MD5sum: d3d3d75a1d9f6d6d2cb18d947a1da407
+SHA1: 3ab0cc0eeacf15b66af4e1731172bbc1037492dd
+SHA256: c78b3fcd807541bf124c6aaba4c0da8c02824c860dcca8c338b0081f71c665ad
+SHA512: 4e019304d6e15e82d44d50efd9d62b46a2bcbbde8b92eb359c854e1e569712c548a3528f767ec0b9ac74ac5b32d3b55023189acab728ab89de0d06490e4dc7fd
+Description: RDP client for Windows Terminal Services (GIT version)
+ FreeRDP is a client for Windows Terminal Services implementing the Remote
+ Desktop Protocol (RDP).
+ .
+ Currently, the following Windows Versions are supported:
+ .
+  * Windows NT Server
+  * Windows 2000 Terminal Server
+  * Windows XP
+  * Windows 2003 Server
+  * Windows Vista
+  * Windows 2008 Server
+  * Windows 7
+ .
+ Homepage: http://www.freerdp.com/
+ Homepage: http://openthinclientalliance.org/
+
+Package: tcos-libs
+Priority: optional
+Section: unknown
+Installed-Size: 32
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-13
+Conflicts: python-tcos
+Filename: ./tcos-libs_2.0-13_i386.deb
+Size: 13886
+MD5sum: b31d30d36e27fdcc781b6d7cc38b9729
+SHA1: 90e837eb7bd434f833ba03fe8ae8791bd18a69eb
+SHA256: 36d953c48c58d60ee32768d3ebd11cb319ac3763ef315d90e5fa7bdfeeb70e47
+SHA512: 14be588cea04ff39e3a8180f8450c584137752727ac7893f13262a844eeebde8fcb205eb5b031024577f77da254ea7201f608520ea561746c89ce22014bb5419
+Description: python libraries for openthinclient
+ This libraries are used by the launchers and and other
+ scripts doing the magic inside a running client.
+
+Package: tcos-scripts
+Priority: optional
+Section: unknown
+Installed-Size: 28
+Maintainer: Joern Frenzel <j.frenzel@openthinclient.com>
+Architecture: i386
+Version: 2.0-40
+Depends: base (>= 2.0-25)
+Conflicts: initscripts-tcos
+Filename: ./tcos-scripts_2.0-40_i386.deb
+Size: 9214
+MD5sum: 9f5d7bfb60ca16cfda91318828da2193
+SHA1: 0e25d81207a59ea1bb6d454c0427cd5eaffa21c0
+SHA256: f3092d09e12ab0d1c8f31ee4ab581174c1260a16a451d34411b7b203e60ae166
+SHA512: dc3ee8c7da63f9f43d2bb41a6fae13520e94d567999472c9314db7489600e0b95bae1ecf62293791148c8f28f3a1b181c050474131a40f5e95d9767ffb034059
+Description: tcos client scripts
+ This scripts are takeing care about the clients configuration,
+ by pulling all the information from the management backend,
+ patching configs etc..
+
+Package: openthinclient-manager
+Priority: optional
+Section: admin
+Installed-Size: 33823
+Maintainer: Simon Tobies <s.tobies@openthinclient.com>
+Architecture: i386
+Version: 1.0.0-4
+Depends: openthinclient-server-ldap
+Filename: ./openthinclient-manager_1.0.0-4_i386.deb
+Size: 34630272
+MD5sum: 7cd7a497c05365730dd060f7184965a4
+SHA1: 40118ceeff5c74713196e31fd58b5426bd4c26c1
+SHA256: b7b4acf194385c224eb5a5b5e04dcfb2e02d1c35150ae1441b7161db03e9ae61
+SHA512: 7482fa8fb85c6682b45b0c1de4866088e6f70e71365d6231c0a23f81a0027bb7d5a82a538883b0dcff72a81562c4b36841ebbaa164a09175900ef745eba1e4d5
+Description: OpenThinClient Manager
+ The "OpenThinClient Manager" provides a powerful, Java-based graphical user
+ interface to manage all aspects of the ThinClients under its control.
+ Furthermore, it supports integration with enterprise-wide management
+ environments like LDAP or MS ADS.
+ .
+ It is build as an "Enterprise Archive" (EAR) containing various modules to be
+ deployed by the JBoss Application Server.
+Is-Package-Manager: yes
+
+Package: rdesktop
+Priority: optional
+Section: x11
+Installed-Size: 490
+Maintainer: Joern Frenzel <t.bauspiess@openthinclient.com>
+Architecture: i386
+Version: 2.0-1.8.2-4
+Depends: base (>= 2.0)
+Filename: ./rdesktop_2.0-1.8.2-4_i386.deb
+Size: 464828
+MD5sum: 50bfacbdadb779fa8bae9e67743d05e9
+SHA1: b444a0859d098be5040b5ecd46591222ad8d0f78
+SHA256: 6271e6a383a798fab36b4c7f1cce4610534bde88f2677250921167faa80382e9
+SHA512: 06c8730861e9fb85e2663ecdf94c6920b928aa41785d809029a2cdfd1f3d5f461e28bec7f395da91563d72eb4f61b5f67b174d39a33ed0510b412ced065c71e2
+Description: RDP client for Windows NT/2000 Terminal Server
+ rdesktop is an open source client for Windows NT/2000 Terminal Server, capable
+ of natively speaking its Remote Desktop Protocol (RDP) in order to present
+ the user's NT/2000 desktop. Unlike Citrix ICA, no server extensions are
+ required.
+
+Package: base
+Essential: yes
+Priority: required
+Section: base
+Installed-Size: 634353
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-25
+Depends: tcos-scripts (>= 2.0-20), tcos-libs (>= 2.0-6), tcos-devices (>= 2.0-7)
+Filename: ./base_2.0-25_i386.deb
+Size: 647696588
+MD5sum: 58e5006d72ed254c47d80a46f64f1939
+SHA1: 2a59771fb74e5ca41973162c6edca64275d1ebcb
+SHA256: 8967a4e4a770231b76f1fc3aa69d5e022dfe6fe494b3c14a165e67e0531ed714
+SHA512: 47c504244fb41e04c5daf2672a98dd817852da917a80844971a127c39ca7b86688ab9c15603016b4558386b4a0a9113bbfa724140d263c82e78090c46ff8e420
+Description: TCOS base system
+ This package contains the operating system files a client will boot on startup.
+
+Package: cups-client
+Priority: optional
+Section: unknown
+Installed-Size: 29
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-2
+Depends: base (>= 2.0)
+Filename: ./cups-client_2.0-2_i386.deb
+Size: 2112
+MD5sum: 0a03b359dca9223814e7c4d1d1f02650
+SHA1: dc972e2352c1bb6fceb0dc18a99f97a72dadf760
+SHA256: 74b4f150e3260c17ee5536fcf8d072dec8e69da43db9d1be279079b5cc2b7c4f
+SHA512: ef5152a8b8f4429e6870f0642629e20f9c7f2aa75bc073bf6bb787d0a7e340a51600886d80bee93b090862e53718b30f29fedd7f89b143944d71a091f185d31f
+Description: allows a CUPS client configuration
+ .
+ If you'd like to print  from within a local session (openthinclient OS) with no
+ remote session in mind (e.g. Iceweasel, Atril (pdfs)), you may connect to an
+ external cupsd.
+ .
+ Warning: It's mandatory that you configure a cupsd to share printers before
+ using this package.
+
+Package: openthinclient-server-dhcp
+Priority: optional
+Section: net
+Installed-Size: 5484
+Maintainer: Simon Tobies <s.tobies@openthinclient.com>
+Architecture: i386
+Version: 1.0.0-1
+Depends: openthinclient-server-ldap
+Filename: ./openthinclient-server-dhcp_1.0.0-1_i386.deb
+Size: 5587554
+MD5sum: 3506741785f6b6a89334dd108281db4c
+SHA1: 0d80e5ef62eadd92422138f2562883cbefa41cbe
+SHA256: 010163a0ce33486e07beeddd367c921f1d328ea2adf7789acda918ec803eb1e9
+SHA512: 7966fff6ec956df38e4d804355e44eeb995d76aef478cf880e6ae93fd6f301c3ce02173adfa0239d60e0e0e77796eb09a24fcbff3b8c2acfd9554bbff03cb3be
+Description: OpenThinClient DHCP (Proxy) Server
+ The "OpenThinClient DHCP (Proxy) Server" listens for PXE discover packets and
+ replies with PXE proxy offers. This server is no DHCP server. It just
+ provides a way to boot PXE ThinClients without interfering other DHCP servers on
+ the network.
+ .
+ It is build as a "Service Archive" (SAR) to be deployed by the JBoss
+ Application Server.
+
+Package: tcos-devices
+Priority: optional
+Section: admin
+Installed-Size: 195
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-19
+Conflicts: openthinclient-schema
+Filename: ./tcos-devices_2.0-19_i386.deb
+Size: 24946
+MD5sum: 3dbb1c86a467c27ae697a5f35321219c
+SHA1: 5642f72caa86a19b4979c790c2e82d6457847597
+SHA256: ef04c4906b39d4dab84ca236a2889f64929f44e95103e72524858cc5f53842c6
+SHA512: 41848925a0809fa90cc4af2b8ffa01a981775d41c106f417e965897184d151d3e931af913572a5d1b119286eba10cdf88a63544265c533951369a7ea302dceda
+Description: Schemas for openthinclient manager
+ Several XML files for devices like displays.
+
+Package: openthinclient-manager
+Priority: optional
+Section: admin
+Installed-Size: 33874
+Maintainer: s.tobies@openthinclient.com
+Architecture: any
+Source: openthinclient-manager
+Version: 1.0.2-1
+Depends: openthinclient-server-ldap
+Filename: ./openthinclient-manager_1.0.2-1_i386.deb
+Size: 34647396
+MD5sum: b54ec6ae391a8611c6f6052f6e03b258
+SHA1: 196316b18baf3df64534f33b5f9518eb75e2d3fc
+SHA256: f80e034bef51a478099767fbc70426e9422230ff47e046dc6fc2d63d18868115
+SHA512: 18a5043a769c09a2196d3aa30fe0ff1e3ef331ff75b46bb543102b3a11eec0e96065f9e26418135acf2804dda2f59c54e11d6ac600d04d18c4ae6fac2509b5e6
+Description: OpenThinClient Manager
+ The "OpenThinClient Manager" provides a powerful, Java-based graphical user
+ interface to manage all aspects of the ThinClients under its control.
+ Furthermore, it supports integration with enterprise-wide management
+ environments like LDAP or MS ADS.
+ .
+ It is build as an "Enterprise Archive" (EAR) containing various modules to be
+ deployed by the JBoss Application Server.
+Homepage: http://www.openthinclient.org
+Is-Package-Manager: yes
+
+Package: cmdline
+Priority: optional
+Section: unknown
+Installed-Size: 29
+Maintainer: Joern Frenzel <j.frenzel@openthinclient.com>
+Architecture: i386
+Version: 2.0-01
+Depends: base (>= 2.0)
+Filename: ./cmdline_2.0-01_i386.deb
+Size: 4440
+MD5sum: a1b08e8ba9431f24d004ad6dacbad949
+SHA1: 054fe09efa746134519c6cb83131bda0bd3e6fc1
+SHA256: ee3d2f9e0510139a7777534f86d217b94142e69a6b32a1fe3c76bcee86d783db
+SHA512: a0e075ca5145434a9d29166080de8c0dcdfc9b216cc8ebfc0471f1a996f8845f01b4bde6d395441478c873ff8e5b37a2bb4213c84f71cb9df8b4ae4ed6246c80
+Description: General commandline application for TCOS
+ General commandline wrapper
+
+Package: sso-tcos
+Priority: optional
+Section: unknown
+Installed-Size: 75
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-4
+Depends: base
+Filename: ./sso-tcos_2.0-4_i386.deb
+Size: 11656
+MD5sum: 9f00be9a355ca827e4ba9de1051c02fb
+SHA1: 8d9d9a81464ebe63ffe06af11af8712170a2c89a
+SHA256: 1fa63ddf9e763326d0583a1aeb961856689dd0b4b3119319baea80cfeef7cb81
+SHA512: da3027465b7b7933740efa694c6a605ec16064bc6b7ee4ab2de7b945d590e820c985361a87180ab5fd39f0dd0028c0839600e356d53d3f11b008606a92072436
+Description: Single-Sign-On addon for appications
+ This package provides single sign on capabilities
+ for applications like rdesktop and ica-client
+Info: SECURITY WARNING
+ .
+ .
+ sso-tcos is a better than nothing implementation of a single-sign-on
+ mechanism which caches the entered password and provides it in an
+ weekly encrypted way via a environment variable to application starters
+ which can restore it to plain text in order to supply the password to
+ the application.
+ .
+ .
+ This package is designed to add convenience but does so at the EXPENSE
+ OF SECURITY. Using it will leave unattended ThinClients vulnerable to
+ spies or colleages trying to snoop out the password of the current user!
+ .
+ .
+ Make sure that everyone is aware of that risk and when in doubt, don't
+ install this package!
+ .
+ .
+ YOU HAVE BEEN WARNED!
+
+Package: openthinclient-server-ldap
+Priority: optional
+Section: net
+Installed-Size: 4156
+Maintainer: Simon Tobies <s.tobies@openthinclient.com>
+Architecture: i386
+Version: 1.0.0-1
+Filename: ./openthinclient-server-ldap_1.0.0-1_i386.deb
+Size: 4238540
+MD5sum: 19a01dab5ce880c29b84f2b0402c8541
+SHA1: 2914aebf2ba31c782e02e594424d5acf8f124245
+SHA256: 83fc0bc658104dc9a881a42e32c51305b28851960a31d636456ac5fac0901c2a
+SHA512: 145255d2e2117e6c8ffc69965c3b578ffccaa65cc8f4aed25183d86b64cfe61d3ab3158ae41164e8b51c5ce1c6fe39e542dfc1445d5ecf6e9a908bb8997be700
+Description: OpenThinClient LDAP Server
+ The "OpenThinClient LDAP Server" is a LDAP (Lightweight Directory Access
+ Protocol) server. It provides a standalone directory service.
+ The "OpenThinClient Manager" stores its configuration informations in a LDAP
+ directory.
+ .
+ It is build as a "Service Archive" (SAR) to be deployed by the JBoss
+ Application Server.
+
+Package: tcos-libs
+Priority: optional
+Section: unknown
+Installed-Size: 32
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-12
+Conflicts: python-tcos
+Filename: ./tcos-libs_2.0-12_i386.deb
+Size: 13340
+MD5sum: 31354df8c4a6c3da0d92f1ade8337dca
+SHA1: 7058ac85636765d58e143c6621b8e6ddb8b27164
+SHA256: ddb88961084b41e595aa822087e623f798a5ef43a94d86d21c34b00854aeccac
+SHA512: 28445955854f22ddbf056d343d2f16af5b997e6da4f12ea9f0e8933b9d610fd820b6db9d5060d249696d2bf28fd3992db2bf89f58c585a3ea80d702d71a0336b
+Description: python libraries for openthinclient
+ This libraries are used by the launchers and and other
+ scripts doing the magic inside a running client.
+
+Package: desktop
+Priority: optional
+Section: unknown
+Installed-Size: 1757
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-15
+Depends: base, tcos-libs (>= 2.0-7)
+Conflicts: tcos-branding
+Filename: ./desktop_2.0-15_i386.deb
+Size: 1769904
+MD5sum: f5fea790b5b7c65ae3bb4efffd2c6728
+SHA1: 9b398693a33da7ed9d3063d97014ca73fda80278
+SHA256: 45406f927f8bfc3cd8e141de169ecb6d9bb749bd8d663fda26a2b67c480bc028
+SHA512: bfb5dae548e0fa5f7c4d2547d7cd03e4206384e0361968da97454e3737a47540190c8fe8da5939afb24f30470abd91644efa28e0d8aceca6bb95bc569641f152
+Description: Customize the TCOS desktop experience.
+
+Package: smartcard-lite
+Priority: optional
+Section: unknown
+Installed-Size: 29
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-2
+Depends: base
+Conflicts: smartcard
+Filename: ./smartcard-lite_2.0-2_i386.deb
+Size: 2482
+MD5sum: 3534647fd1d842b4cd2e22d680132f14
+SHA1: 945c65a5a71f20716aabb844ab93d6b927631114
+SHA256: 680887b3a8281bba56a0bf67863f5d7d8acd6bde82bd823388c2d07bec87744c
+SHA512: d01b1ea43cb49f7186db0f3a839989379c869d25e17358e2406870d9db4fa864470a339f595096d9165f27c8177b0af6a3501c35e2534f002f5c3cace0aaebac
+Description: automates the invocation of pcscd
+
+Package: openthinclient-server-nfs
+Priority: optional
+Section: net
+Installed-Size: 1976
+Maintainer: Simon Tobies <s.tobies@openthinclient.com>
+Architecture: i386
+Version: 1.0.0-1
+Filename: ./openthinclient-server-nfs_1.0.0-1_i386.deb
+Size: 2004770
+MD5sum: 39c5a1c92d21187f2fb0f314af1ac3e2
+SHA1: c4ffc242838ff6587420a540386e9b17a80790a1
+SHA256: d81f35dab907e7703d26b0872e5c8993bab4a544cdeaf3b2387b518056fb760f
+SHA512: ceada58d690da94d08997e1b60d0d8647ae45f64988ef7fbc1bc7c40f797552c11436b12a077ab134c44a03a85a6eadfd7ad3f68a4bdb2925f16df0986617fdd
+Description: OpenThinClient NFS Server
+ The "OpenThinClient NFS Server" contains all necessary programs to make your
+ machine act as an NFS server, being an NFS and a mount daemon.
+ ThinClients do mount their root and user-home directory via NFS.
+ .
+ It is build as a "Service Archive" (SAR) to be deployed by the JBoss
+ Application Server.
+
+Package: ica-client-12
+Priority: optional
+Section: unknown
+Installed-Size: 2996
+Maintainer: Joern Frenzel <j.frenzel@openthinclient.com>
+Architecture: i386
+Version: 2.0-12.1-13
+Provides: ica-client
+Depends: base (>= 2.0)
+Conflicts: ica-client, ica-client-11, ica-client-12
+Filename: ./ica-client-12_2.0-12.1-13_i386.deb
+Size: 3015984
+MD5sum: 72043bc7b1efa40b75344809a04f520c
+SHA1: a93a15888f522e0011260ead1620815da0803ee8
+SHA256: 2211e0a8aed4fe743cd922c174d16c0384c91dc66d006715da224d1d1ac7f843
+SHA512: 71ac9e5209e417eb4521b6125a698a94be62514ec1018a1c4012c60f665f0380ca32b0f11123e19fbf0666274bd52c3a74f278f7e0048387940ea236444715bf
+Description: Citrix Receiver Version 12.x
+ Citrix Receiver for UNIX Version 12.x.
+ For the latest information on this, and other Citrix Systems, Inc.
+ products, please visit the following Web site at:
+ .
+ .
+ http://www.citrix.com/
+License: CITRIX(R) ICA CLIENT LICENSE AGREEMENT
+ .
+ .
+ BY CLICKING "I ACCEPT" BELOW, YOU ARE AGREEING TO BE BOUND BY THE TERMS OF THIS
+ LICENSE AND REPRESENTING THAT YOU HAVE THE AUTHORITY TO ENTER INTO THIS LICENSE
+ ON BEHALF OF YOUR COMPANY ("YOU").
+ .
+ .
+ .
+ Use of this component is subject to the Citrix license covering the Citrix
+ product(s) with which you will be using this component. This component is only
+ licensed for use with such Citrix product(s).
+ .
+ .
+ YOU ARE NOT ALLOWED TO:
+ .
+ .
+ (i) using, copying (except as necessary for back-up or archival purposes or to
+ the extent expressly permitted by applicable law and to the extent that Citrix
+ is not permitted by that applicable law to exclude or limit such rights),
+ modifying, or transferring the Citrix Deliverables or Products or any copy in
+ whole or in part, or granting any rights in the Citrix Deliverables or
+ Products;
+ .
+ .
+ (ii) translating, reverse engineering, decompiling, disassembling, or creating
+ derivative works based on the Citrix Deliverables or Products; or
+ .
+ .
+ (iii) renting or leasing the Citrix Deliverables or Products.
+ .
+ .
+ (iv) use, export or re-export the Citrix Deliverables in any form without the
+ appropriate government licenses.
+ .
+ .
+ CITRIX AND ITS SUPPLIERS MAKE AND YOU RECEIVE NO WARRANTIES OR CONDITIONS,
+ EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, AND CITRIX AND ITS SUPPLIERS
+ SPECIFICALLY DISCLAIM ANY CONDITIONS OF QUALITY AND ANY IMPLIED WARRANTIES,
+ INCLUDING, WITHOUT LIMITATION, ANY WARRANTY OF MERCHANTABILITY,
+ NONINFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE. YOU ASSUME THE
+ RESPONSIBILITY FOR THE USE OF, AND RESULTS OBTAINED FROM THE CITRIX
+ DELIVERABLES.
+ .
+ .
+ IN NO EVENT SHALL THE LIABILITY OF CITRIX, ITS AFFILIATES OR SUPPLIERS EXCEED
+ ONE HUNDRED US DOLLARS ($100.00). SOME JURISDICTIONS DO NOT ALLOW THE
+ LIMITATION OR EXCLUSION OF LIABILITY FOR INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+ SO THE ABOVE LIMITATION OR EXCLUSION MAY NOT APPLY TO YOU.
+ .
+ .
+ .
+ Citrix Systems, Inc.
+ .
+ 851 West Cypress Creek Road
+ .
+ Fort Lauderdale, FL 33309
+ .
+ 1-800-437-7503
+ .
+ http://www.citrix.com/
+
+Package: printserver
+Priority: optional
+Section: unknown
+Installed-Size: 30
+Maintainer: Steffen Hoenig <s.hoenig@openthinclient.com>
+Architecture: i386
+Version: 2.0-3
+Depends: base (>= 2.0-13)
+Filename: ./printserver_2.0-3_i386.deb
+Size: 5614
+MD5sum: 6304362d1446044e4e6138b04a454509
+SHA1: a2b1d6c9d7020020ef403619a08bf3e4e3d6b7a6
+SHA256: 3fdcaf1c84ea7b6dc9e7a93d3dcc209d1a66292f0caebd4fb06a62634408ce94
+SHA512: 88fe51b684bf6ad1d141ed3d65e68adbedd928df5e62c81bc20d0f1bd103b4270778e1396f0cb81331d533bdab26a4b96d4edb73f5f2293b4372be0da1b8e407
+Description: Printserver (HP JetDirect emulation)
+ HP JetDirect printserver emulation. The printserver can be configured to
+ listen on a specific TCP port. Received data is send raw to an attached
+ parallel or usb printer.
+ .
+ To get the device specific string, you may boot the client with the printer
+ plugged in and have a look at the path '/dev/usb/lp/'. The string combines the
+ hardware name with the corresponding serial.
+ Another approach would be to use 'udevadm monitor --environment --udev' and
+ look for a tag named ID_SERIAL
+ .
+ To use classes of the same printer instead (for instance you want to assign
+ any HP DeskJet F300 instead of one special printer) you can also insert
+ usb-ids. To get them, plainly use lsusb and use the number separated by a
+ colon behind "ID" e.G. 0a12:0001
+ .
+ Additionally the following AS/400 protocols/drivers are supported:
+ .
+ - IBMPJLDRV
+ .
+ - HPPJLDRV
+ .
+ - NETSTNDRV
+


### PR DESCRIPTION
In previous versions a simple serialization based format has been used to persist the database. This pull request introduces a pluggable Package Database mechanism, that allows to use both types of storage.

In addition, there was some simplification done to make reading and maintaining the package manager simpler
