### PR TITLE
fix calculation of free disk space

### DIFF
--- a/advisor/src/main/java/org/openthinclient/advisor/check/CheckFilesystemFreeSpace.java
+++ b/advisor/src/main/java/org/openthinclient/advisor/check/CheckFilesystemFreeSpace.java
@@ -38,8 +38,8 @@ public class CheckFilesystemFreeSpace extends AbstractCheck<Boolean> {
   protected CheckExecutionResult<Boolean> perform() {
     
     final Path installDir = this.pathSupplier.get(); 
-    long freeSpace = installDir.getRoot().toFile().getFreeSpace();
-    LOG.info("Free space for '" + installDir.getRoot() + "' is " + freeSpace + " bytes (" + (freeSpace/1024/1024) + "Mb)");
+    long freeSpace = installDir.toFile().getFreeSpace();
+    LOG.info("Free space for '" + installDir + "' is " + freeSpace + " bytes (" + (freeSpace/1024/1024) + "Mb)");
     
     if (minFreeSpace == 0) {
       return new CheckExecutionResult<>(CheckExecutionResult.CheckResultType.WARNING, true);


### PR DESCRIPTION
Having the otc directories mounted on separate volumes, the setup routine may fail because the free disk space is calculated from getRoot(). 

fixes openthinclient/openthinclient-manager#29